### PR TITLE
Add GITHUB_ORGANIZATION_LOGIN environment variable

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -29,6 +29,10 @@ SECRET_KEY_BASE=
 # - that will be used to request reviews from other contributors
 GITHUB_ACCESS_TOKEN=
 
+# The GitHub organization login that will be used to match pull requests
+# Pull requests in repositories from outside this organization will be ignored
+GITHUB_ORGANIZATION_LOGIN=
+
 # Configuration file URL for stacks and blacklisted reviewers
 CONFIGURATION_FILE_URL=
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -9,6 +9,8 @@ config :dispatch, Dispatch.Endpoint,
 # Print only warnings and errors during test
 config :logger, level: :warn
 
+config :dispatch, DispatchWeb.Webhooks, github_organization_login: "mirego"
+
 config :dispatch, Dispatch,
   repositories_client: Dispatch.Repositories.MockClient,
   settings_client: Dispatch.Settings.MockClient,

--- a/rel/config/config.exs
+++ b/rel/config/config.exs
@@ -84,6 +84,9 @@ config :sentry,
   root_source_code_path: File.cwd!(),
   enable_source_code_context: true
 
+# Configure Webhooks
+config :dispatch, DispatchWeb.Webhooks, github_organization_login: Environment.get("GITHUB_ORGANIZATION_LOGIN")
+
 # Configure clients
 config :dispatch, Dispatch,
   repositories_client: Dispatch.Repositories.GitHubClient,


### PR DESCRIPTION
We now use the `GITHUB_ORGANIZATION_LOGIN` environment variable to make sure pull requests are within a specific organization.

I had to refactor the code to avoid matching directly in the function arguments since we want this variable to be evaluated at runtime.