### PR TITLE
Add possibility to mute learners for a repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Everything is done via a simple GitHub webhook:
 | Parameter          | Default value | Description                                                        |
 |--------------------|---------------|--------------------------------------------------------------------|
 | `stacks`           | `[]`          | Comma-separated values of project’s stacks (e.g. `elixir,graphql`) |
-| `disable_learners` | `false`       | Disable _learners_ for this project                                |
+| `disable_learners` | `false`       | Disable _learners_ for this repository                             |
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,18 @@ Dispatch gets notified about pull requests opened in GitHub projects. It then se
 
 Everything is done via a simple GitHub webhook:
 
-| Field        | Value                                                                  |
-|--------------|------------------------------------------------------------------------|
-| Payload URL  | `<dispatch URL>/webhooks?stacks=first_stack,second_stack`              |
-| Content type | `application/json`                                                     |
-| Events       | Send me **everything**.                                                |
+| Field        | Value                                  |
+|--------------|----------------------------------------|
+| Payload URL  | `https://my-dispatch-app.com/webhooks` |
+| Content type | `application/json`                     |
+| Events       | Send me **everything**.                |
+
+#### Webhook query string parameters
+
+| Parameter          | Default value | Description                                                        |
+|--------------------|---------------|--------------------------------------------------------------------|
+| `stacks`           | `[]`          | Comma-separated values of project’s stacks (e.g. `elixir,graphql`) |
+| `disable_learners` | `false`       | Disable _learners_ for this project                                |
 
 ### Features
 

--- a/lib/dispatch/dispatch.ex
+++ b/lib/dispatch/dispatch.ex
@@ -32,7 +32,7 @@ defmodule Dispatch do
   @doc """
   Returns a list of usernames that should be request to review the pull request
   """
-  def fetch_selected_users(repo, stacks, author_username) do
+  def fetch_selected_users(repo, stacks, author_username, disable_learners \\ false) do
     excluded_usernames = [author_username | Enum.map(Settings.blacklisted_users(), & &1.username)]
 
     # 1. Refresh settings
@@ -55,7 +55,7 @@ defmodule Dispatch do
     requestable_usernames = update_requestable_usernames(requestable_usernames, Enum.map(contributors, & &1.username))
 
     # 5. Update the pool and then randomly add -learners as reviewers for each stack
-    stack_learners = Settings.learners(requestable_usernames, stacks)
+    stack_learners = if disable_learners, do: [], else: Settings.learners(requestable_usernames, stacks)
 
     # 6. Map all selected users to SelectedUser struct
     Enum.map(contributors ++ stack_experts ++ stack_learners, &struct(SelectedUser, Map.from_struct(&1)))

--- a/lib/dispatch_web/webhooks/controller.ex
+++ b/lib/dispatch_web/webhooks/controller.ex
@@ -25,7 +25,8 @@ defmodule DispatchWeb.Webhooks.Controller do
     repo = get_in(params, ["repository", "full_name"])
 
     stacks = Dispatch.extract_from_params(params)
-    selected_users = Dispatch.fetch_selected_users(repo, stacks, author)
+    disable_learners = string_to_boolean(Map.get(params, "disable_learners"))
+    selected_users = Dispatch.fetch_selected_users(repo, stacks, author, disable_learners)
 
     repo
     |> Dispatch.request_reviewers(pull_request_number, selected_users)
@@ -39,4 +40,8 @@ defmodule DispatchWeb.Webhooks.Controller do
   end
 
   defp github_organization_login, do: Application.get_env(:dispatch, DispatchWeb.Webhooks)[:github_organization_login]
+
+  defp string_to_boolean("true"), do: true
+  defp string_to_boolean("1"), do: true
+  defp string_to_boolean(_), do: false
 end


### PR DESCRIPTION
Since we open source Dispatch, it will be used on open source projects. Those projects might be backed by a corporation that doesn’t want to expose which person is learning what.

We can now disable `learners` by using `disable_learners=true` within the webhook’s query string.

✌️ 