### PR TITLE
Enforce Erlang version like we enforce Elixir version

### DIFF
--- a/lib/mix/tasks/erlang.check_version.ex
+++ b/lib/mix/tasks/erlang.check_version.ex
@@ -1,0 +1,40 @@
+defmodule Mix.Tasks.Erlang.CheckVersion do
+  use Mix.Task
+
+  @shortdoc "Check the Erlang/OTP version"
+
+  @impl true
+  def run(args) do
+    config = Mix.Project.config()
+
+    check_erlang_version(config, args)
+  end
+
+  defp check_erlang_version(config, _) do
+    app = ":#{Keyword.get(config, :app)}"
+    expected_version = Keyword.get(config, :erlang)
+    actual_version = otp_release_version()
+
+    if actual_version != expected_version do
+      Mix.raise("You're trying to run #{app} on Erlang/OTP #{actual_version} but it has declared in its mix.exs file it supports only Erlang/OTP #{expected_version}")
+    end
+  end
+
+  defp otp_release_version do
+    [
+      :code.root_dir(),
+      "releases",
+      :erlang.system_info(:otp_release),
+      "OTP_VERSION"
+    ]
+    |> Path.join()
+    |> File.read()
+    |> case do
+      {:ok, version} ->
+        String.trim(version)
+
+      _ ->
+        nil
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Dispatch.Mixfile do
       app: :dispatch,
       version: "1.0.2",
       elixir: "1.7.4",
+      erlang: "21.1.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       test_paths: ["test"],
       test_pattern: "**/*_test.exs",
@@ -13,6 +14,7 @@ defmodule Dispatch.Mixfile do
       preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test],
       compilers: [:phoenix] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
+      aliases: aliases(),
       deps: deps()
     ]
   end
@@ -67,6 +69,12 @@ defmodule Dispatch.Mixfile do
       # Test
       {:mock, "~> 0.2.0", only: :test},
       {:mox, "~> 0.4.0", only: :test}
+    ]
+  end
+
+  defp aliases do
+    [
+      "compile.app": ["erlang.check_version", "compile.app"]
     ]
   end
 end


### PR DESCRIPTION
The `lib/mix/tasks/erlang.check_version.ex` file was extracted from our (soon to be open-source) Elixir Boilerplate project.