### PR TITLE
Add spec for learners when body is overriden

### DIFF
--- a/test/dispatch_web/webhooks/controller_test.exs
+++ b/test/dispatch_web/webhooks/controller_test.exs
@@ -17,7 +17,8 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
     %User{username: "bar", fullname: "bar"},
     %User{username: "pif", fullname: "pif"},
     %User{username: "paf", fullname: "paf"},
-    %User{username: "ruby-master", fullname: "The Ruby Master"}
+    %User{username: "ruby-master", fullname: "The Ruby Master"},
+    %User{username: "ruby-learner", fullname: "The Ruby Learner"}
   ]
   @contributors [
     %Contributor{username: "bar", relevancy: 1, recent_commit_count: 1, total_commit_count: 1},
@@ -233,7 +234,8 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
                                           1,
                                           [
                                             %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 1, total_commit_count: 1}},
-                                            %SelectedUser{username: "ruby-master", type: "stack", metadata: %{stack: "ruby"}}
+                                            %SelectedUser{username: "ruby-master", type: "stack", metadata: %{stack: "ruby"}},
+                                            %SelectedUser{username: "ruby-learner", type: "learner", metadata: %{stack: "ruby"}}
                                           ] ->
       :ok
     end)
@@ -261,6 +263,11 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
                  "metadata" => %{"stack" => "ruby"},
                  "type" => "stack",
                  "username" => "ruby-master"
+               },
+               %{
+                 "metadata" => %{"stack" => "ruby", "exposure" => 1},
+                 "type" => "learner",
+                 "username" => "ruby-learner"
                }
              ]
            }


### PR DESCRIPTION
This morning, a PR was opened with a body override and _learners_ weren’t assigned. I wanted to fix this issue and when I wrote my test I realized that everything was working properly.

Turns out the submitter added the tag by editing the PR which is not supported for now.

Since the test is written, we might as well merge it :)