### PR TITLE
Avoid calling GitHub API with empty data

### DIFF
--- a/lib/dispatch/repositories/github_client.ex
+++ b/lib/dispatch/repositories/github_client.ex
@@ -27,6 +27,8 @@ defmodule Dispatch.Repositories.GitHubClient do
   @doc """
   Given a repo, a pull request and a list of reviewers, request them as reviewers using the REST API.
   """
+  def request_reviewers(_, _, []), do: :ok
+
   def request_reviewers(repo, pull_request_number, reviewers) do
     url = "/repos/#{repo}/pulls/#{pull_request_number}/requested_reviewers"
 
@@ -46,6 +48,8 @@ defmodule Dispatch.Repositories.GitHubClient do
   @doc """
   Given a repo, a pull request and a list of reviewers, create a comment documenting why the reviewers were chosen using the REST API.
   """
+  def create_request_comment(_, _, []), do: :ok
+
   def create_request_comment(repo, pull_request_number, reviewers) do
     url = "/repos/#{repo}/issues/#{pull_request_number}/comments"
 

--- a/test/dispatch/repositories/github_client_test.exs
+++ b/test/dispatch/repositories/github_client_test.exs
@@ -215,7 +215,11 @@ defmodule Dispatch.Repositories.GitHubClientTest do
     end
   end
 
-  test "request_reviewers/1 with successful response" do
+  test "request_reviewers/3 without reviewers" do
+    assert :ok == GitHubClient.request_reviewers("mirego/foo", 123, [])
+  end
+
+  test "request_reviewers/3 with successful response" do
     expected_url = "https://api.github.com/repos/mirego/foo/pulls/123/requested_reviewers"
     body = "{\"reviewers\":[\"morpheus\",\"neo\"]}"
 
@@ -225,7 +229,7 @@ defmodule Dispatch.Repositories.GitHubClientTest do
     end
   end
 
-  test "request_reviewers/1 with non-successful response" do
+  test "request_reviewers/3 with non-successful response" do
     expected_url = "https://api.github.com/repos/mirego/foo/pulls/123/requested_reviewers"
     body = "{\"reviewers\":[\"morpheus\",\"neo\"]}"
 
@@ -235,7 +239,7 @@ defmodule Dispatch.Repositories.GitHubClientTest do
     end
   end
 
-  test "request_reviewers/1 with erroneous response" do
+  test "request_reviewers/3 with erroneous response" do
     expected_url = "https://api.github.com/repos/mirego/foo/pulls/123/requested_reviewers"
     body = "{\"reviewers\":[\"morpheus\",\"neo\"]}"
 
@@ -243,6 +247,10 @@ defmodule Dispatch.Repositories.GitHubClientTest do
       assert :error ==
                GitHubClient.request_reviewers("mirego/foo", 123, [%SelectedUser{username: "morpheus", type: "contributor"}, %SelectedUser{username: "neo", type: "stack/assembler"}])
     end
+  end
+
+  test "create_request_comment/3 without reviewers" do
+    assert :ok == GitHubClient.create_request_comment("mirego/foo", 123, [])
   end
 
   test "create_request_comment/3 with successful response" do


### PR DESCRIPTION
We now avoid requesting reviewers and posting a request comment with an empty list.

Closes #7 