### PR TITLE
Deploy the OTP release to Heroku

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,9 +5,8 @@ deps/
 test/
 priv/static/
 
+*.md
 .*
 coveralls.json
 docker-compose.yml
 Makefile
-CODE_OF_CONDUCT.md
-README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,13 @@
-_build/
 .git/
+.elixir_ls/
+_build/
 deps/
 test/
 priv/static/
 
 .*
+coveralls.json
 docker-compose.yml
 Makefile
+CODE_OF_CONDUCT.md
 README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # App artifacts
+/.elixir_ls
 /_build
 /db
 /deps
@@ -7,12 +8,6 @@
 # Generated on crash by the VM
 erl_crash.dump
 
-# Generated on crash by NPM
-npm-debug.log
-
-# Static artifacts
-/assets/node_modules
-
 # Since we are building assets from assets/,
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.
@@ -20,15 +15,7 @@ npm-debug.log
 
 # Files matching config/*.secret.exs pattern contain sensitive
 # data and you should not commit them into version control.
-#
-# Alternatively, you may comment the line below and commit the
-# secrets files as long as you replace their contents by environment
-# variables.
 /config/*.secret.exs
-
-# Dialyzer plts are stored in the repo to allow CI to cache the files
-/priv/plts/*.plt
-/priv/plts/*.plt.hash
 
 # Local environment variable files
 .env.local

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: 'elixir'
 
 elixir: 1.8.1
-otp_release: 21.2.6
+otp_release: 21.2.7
 
 cache:
   directories:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Step 1 - build the OTP binary
 #
-FROM elixir:1.7.4-alpine AS builder
+FROM elixir:1.8.1-alpine AS builder
 
 ARG APP_NAME
 ARG APP_VERSION
@@ -16,7 +16,7 @@ WORKDIR /build
 # This step installs all the build tools we'll need
 RUN apk update && \
     apk upgrade --no-cache && \
-    apk add --no-cache git build-base python
+    apk add --no-cache make git openssl-dev python
 RUN mix local.rebar --force && \
     mix local.hex --force
 
@@ -38,7 +38,7 @@ RUN cd /opt/build && \
 #
 # Step 2 - build a lean runtime container
 #
-FROM alpine:3.8
+FROM alpine:3.9
 
 ARG APP_NAME
 ENV APP_NAME=${APP_NAME}
@@ -46,7 +46,7 @@ ENV APP_NAME=${APP_NAME}
 # Update kernel and install runtime dependencies
 RUN apk --no-cache update && \
     apk --no-cache upgrade && \
-    apk --no-cache add bash openssl ca-certificates erlang-crypto
+    apk --no-cache add bash openssl erlang-crypto
 
 WORKDIR /opt/dispatch
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
-# The version of Alpine to use for the final image have to match
-# the version `elixir:1.7.3-alpine`/`erlang:21-alpine` are based on.
-ARG ALPINE_VERSION=3.8
-
 #
 # Step 1 - build the OTP binary
 #
@@ -31,8 +27,6 @@ RUN mix deps.get --only ${MIX_ENV}
 COPY . .
 RUN mix compile --force
 
-RUN mix phx.digest
-
 RUN mkdir -p /opt/build && \
     mix release --verbose && \
     cp _build/${MIX_ENV}/rel/${APP_NAME}/releases/${APP_VERSION}/${APP_NAME}.tar.gz /opt/build
@@ -44,7 +38,7 @@ RUN cd /opt/build && \
 #
 # Step 2 - build a lean runtime container
 #
-FROM alpine:${ALPINE_VERSION}
+FROM alpine:3.8
 
 ARG APP_NAME
 ENV APP_NAME=${APP_NAME}
@@ -52,7 +46,7 @@ ENV APP_NAME=${APP_NAME}
 # Update kernel and install runtime dependencies
 RUN apk --no-cache update && \
     apk --no-cache upgrade && \
-    apk --no-cache add bash openssl
+    apk --no-cache add bash openssl ca-certificates erlang-crypto
 
 WORKDIR /opt/dispatch
 

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: mix phx.server

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ If an Absence.io iCal URL is provided, users that are out-of-office when a pull 
 
 ## 🚧 Dependencies
 
-* Elixir (`1.7.4`)
-* Erlang (`21.1.2`)
+* Elixir (`1.8.1`)
+* Erlang (`21.2.7`)
 
 ## 🏎 Setup
 
@@ -171,9 +171,31 @@ The most common reasons as to why there was fewer requested reviews that usual (
 
 ## 🚀 Deploy
 
-The application can be deployed on Heroku following the  [Container Registry & Runtime](https://devcenter.heroku.com/articles/container-registry-and-runtime) guide.
+The application can be deployed to Heroku following the [Container Registry & Runtime](https://devcenter.heroku.com/articles/container-registry-and-runtime) guide.
 
-1. Create a docker image for the _OTP release_ `make build DOCKER_IMAGE_TAG=latest`
-2. Tag the image for Heroky’s registry `docker tag dispatch:latest registry.heroku.com/dispatch/web`
-3. Push the image to the registry `docker push registry.heroku.com/dispatch/web`
-4. Release the image `heroku container:release web`
+### tl;dr
+
+1. Create a docker image for the _OTP release_ (`DOCKER_IMAGE_TAG=latest` is the default value).
+    ```shell
+    > make build DOCKER_IMAGE_TAG=latest
+    ```
+
+1. Tag the image for Heroky’s registry
+    ```shell
+    > docker tag dispatch:latest registry.heroku.com/dispatch/web
+    ```
+
+1. Login to the Heroku registry
+    ```shell
+    > heroku container:login
+    ```
+
+1. Push the image to the registry
+    ```shell
+    > docker push registry.heroku.com/dispatch/web
+    ```
+
+1. Release the image
+    ```shell
+    > heroku container:release web
+    ```

--- a/README.md
+++ b/README.md
@@ -171,10 +171,9 @@ The most common reasons as to why there was fewer requested reviews that usual (
 
 ## 🚀 Deploy
 
-### Heroku
+The application can be deployed on Heroku following the  [Container Registry & Runtime](https://devcenter.heroku.com/articles/container-registry-and-runtime) guide.
 
-The application can be deployed on Heroku using the [`heroku-buildpack-elixir`](https://github.com/HashNuke/heroku-buildpack-elixir.git) buildpack.
-
-### OTP release
-
-An _OTP release_ can be created with `make build`.
+1. Create a docker image for the _OTP release_ `make build DOCKER_IMAGE_TAG=latest`
+2. Tag the image for Heroky’s registry `docker tag dispatch:latest registry.heroku.com/dispatch/web`
+3. Push the image to the registry `docker push registry.heroku.com/dispatch/web`
+4. Release the image `heroku container:release web`

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,4 +1,10 @@
 use Mix.Config
 
 # Do not print debug messages in production
+
+config :dispatch, DispatchWeb.Endpoint,
+  root: '.',
+  server: true,
+  version: Application.spec(:dispatch, :vsn)
+
 config :logger, level: :info

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,8 +1,0 @@
-# Erlang version
-erlang_version=21.1.2
-
-# Elixir version
-elixir_version=1.7.4
-
-# Always rebuild from scratch on every deploy?
-always_rebuild=false

--- a/mix.exs
+++ b/mix.exs
@@ -50,10 +50,6 @@ defmodule Dispatch.Mixfile do
       # Errors
       {:sentry, "~> 6.2"},
 
-      # Linting
-      {:credo, "~> 1.0.0", only: [:dev, :test]},
-      {:credo_envvar, "~> 0.1.0", only: ~w(dev test)a, runtime: false},
-
       # Date/time management
       {:timex, "~> 3.1"},
 
@@ -63,12 +59,16 @@ defmodule Dispatch.Mixfile do
       # OTP Release
       {:distillery, "~> 2.0"},
 
-      # Test coverage
-      {:excoveralls, "~> 0.10", only: :test},
+      # Linting
+      {:credo, "~> 1.0.0", only: ~w(dev test)a, runtime: false},
+      {:credo_envvar, "~> 0.1.0", only: ~w(dev test)a, runtime: false},
 
       # Test
       {:mock, "~> 0.2.0", only: :test},
-      {:mox, "~> 0.4.0", only: :test}
+      {:mox, "~> 0.4.0", only: :test},
+
+      # Test coverage
+      {:excoveralls, "~> 0.10", only: :test}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Dispatch.Mixfile do
       app: :dispatch,
       version: "1.0.3",
       elixir: "1.8.1",
-      erlang: "21.2.6",
+      erlang: "21.2.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       test_paths: ["test"],
       test_pattern: "**/*_test.exs",


### PR DESCRIPTION
The OTP/docker setup was made before the repository was open-sourced, but deployment still based on Heroku codebase deployment using buildpacks and `mix phx.server`. Let’s change that to enforce the recommended way to deploy elixir and erlang application to production using _releases_!