### PR TITLE
Make pull request “body stacks” work even without default stacks

### DIFF
--- a/lib/dispatch/dispatch.ex
+++ b/lib/dispatch/dispatch.ex
@@ -83,7 +83,9 @@ defmodule Dispatch do
   @doc """
   Extracts stacks from a Webhook payload received from GitHub
   """
-  def extract_from_params(%{"pull_request" => %{"body" => body}, "stacks" => default_stacks}) when is_binary(default_stacks) do
+  def extract_from_params(%{"pull_request" => %{"body" => body}} = params) do
+    default_stacks = Map.get(params, "stacks", "")
+
     ~r/#dispatch\/(\w+)/i
     |> Regex.scan(body, capture: :all_but_first)
     |> (fn

--- a/test/dispatch/dispatch_test.exs
+++ b/test/dispatch/dispatch_test.exs
@@ -261,4 +261,18 @@ defmodule DispatchTest do
 
     assert stacks == ["hcl", "ruby"]
   end
+
+  test "extract_from_params/1 with stacks in pull request body but no default ones, it should return them" do
+    body = """
+    This is my pull request! It adds a Terraform configuration file. Absolutely no GraphQL stuff to review.
+
+    Also, there are no default stacks in the webhook URL.
+
+    #dispatch/hcl #dispatch/Ruby
+    """
+
+    stacks = Dispatch.extract_from_params(%{"pull_request" => %{"body" => body}})
+
+    assert stacks == ["hcl", "ruby"]
+  end
 end


### PR DESCRIPTION
`Dispatch.extract_from_params/1` assumed that there always was a `stacks` query parameter present in the webhook URL. It means pull requests in repositories without default stacks were always stackless.

Now it doesn’t anymore 😄