### PR TITLE
Add explicit “expert” term in request comment

### DIFF
--- a/lib/dispatch/dispatch.ex
+++ b/lib/dispatch/dispatch.ex
@@ -99,7 +99,7 @@ defmodule Dispatch do
 
   def extract_from_params(_), do: []
 
-  def request_or_mention_reviewer?(%SelectedUser{type: type}) when type in ["contributor", "stack"], do: :request
+  def request_or_mention_reviewer?(%SelectedUser{type: type}) when type in ["contributor", "expert"], do: :request
   def request_or_mention_reviewer?(_), do: :mention
 
   defp update_requestable_usernames(requestable_usernames, reviewer_usernames) do

--- a/lib/dispatch/repositories/request_comments.ex
+++ b/lib/dispatch/repositories/request_comments.ex
@@ -16,16 +16,16 @@ defmodule Dispatch.Repositories.RequestComments do
   Given a list of 3 reviewers
 
   %{username: "John", type: "contributor", metadata: %{relevancy: "23/99"}}
-  %{username: "Jane", type: "stack", metadata: %{stack: "elixir"}}
-  %{username: "Joe", type: "stack", metadata: %{stack: "graphql"}}
+  %{username: "Jane", type: "expert", metadata: %{stack: "elixir"}}
+  %{username: "Joe", type: "expert", metadata: %{stack: "graphql"}}
   %{username: "Jerry", type: "learner"}
 
   So reviewers will be displayed like this:
 
   @John (contributor with 23% relevancy)
-  @Jane (reviewer for the elixir stack)
-  @Joe (reviewer for the graphql stack)
-  @Jerry (learner)
+  @Jane (expert reviewer for the elixir stack)
+  @Joe (expert reviewer for the graphql stack)
+  @Jerry (learner reviewer)
   """
   def request_comment(reviewers) do
     requested_reviewer_lines =
@@ -49,15 +49,19 @@ defmodule Dispatch.Repositories.RequestComments do
     "* @#{username} (contributor with `#{recent_commit_count}` commits in the last #{relevant_activity_days} days and `#{total_commit_count}` commits overall)\n"
   end
 
-  defp reviewer_line(%{username: username, type: "stack", metadata: %{stack: stack}}) do
-    "* @#{username} (reviewer for the `#{stack}` stack)\n"
+  defp reviewer_line(%{username: username, type: "expert", metadata: %{stack: stack}}) do
+    "* @#{username} (expert reviewer for the `#{stack}` stack)\n"
   end
 
   defp reviewer_line(%{username: username, type: "learner", metadata: %{stack: stack}}) do
-    "* @#{username} (learner for the `#{stack}` stack)\n"
+    "* @#{username} (learner reviewer for the `#{stack}` stack)\n"
+  end
+
+  defp reviewer_line(%{username: username, type: "contributor"}) do
+    "* @#{username} (contributor)\n"
   end
 
   defp reviewer_line(%{username: username, type: type}) do
-    "* @#{username} (#{type})\n"
+    "* @#{username} (#{type} reviewer)\n"
   end
 end

--- a/lib/dispatch/settings/settings.ex
+++ b/lib/dispatch/settings/settings.ex
@@ -44,7 +44,7 @@ defmodule Dispatch.Settings do
   end
 
   defp add_to_experts(acc, users, stack) do
-    users = Enum.map(users, &%Expert{username: &1, type: "stack", metadata: %{stack: stack}})
+    users = Enum.map(users, &%Expert{username: &1, type: "expert", metadata: %{stack: stack}})
 
     update_in(acc, [:experts], &(&1 ++ users))
   end

--- a/test/dispatch/dispatch_test.exs
+++ b/test/dispatch/dispatch_test.exs
@@ -47,7 +47,7 @@ defmodule DispatchTest do
              },
              %SelectedUser{
                metadata: %{stack: "graphql"},
-               type: "stack",
+               type: "expert",
                username: "biz"
              }
            ]

--- a/test/dispatch/repositories/github_client_test.exs
+++ b/test/dispatch/repositories/github_client_test.exs
@@ -253,31 +253,31 @@ defmodule Dispatch.Repositories.GitHubClientTest do
 
   test "create_request_comment/3 with successful response" do
     expected_url = "https://api.github.com/repos/mirego/foo/issues/123/comments"
-    body = "{\"body\":\"**🦀 Requesting reviewers for this pull request:**\\n\\n* @morpheus (contributor)\\n* @neo (stack)\"}"
+    body = "{\"body\":\"**🦀 Requesting reviewers for this pull request:**\\n\\n* @morpheus (contributor)\\n* @neo (expert reviewer)\"}"
 
     with_mock HTTPoison, post: fn ^expected_url, ^body, _ -> {:ok, %HTTPoison.Response{status_code: 201}} end do
       assert :ok ==
-               GitHubClient.create_request_comment("mirego/foo", 123, [%SelectedUser{username: "morpheus", type: "contributor"}, %SelectedUser{username: "neo", type: "stack"}])
+               GitHubClient.create_request_comment("mirego/foo", 123, [%SelectedUser{username: "morpheus", type: "contributor"}, %SelectedUser{username: "neo", type: "expert"}])
     end
   end
 
   test "create_request_comment/3 with non-successful response" do
     expected_url = "https://api.github.com/repos/mirego/foo/issues/123/comments"
-    body = "{\"body\":\"**🦀 Requesting reviewers for this pull request:**\\n\\n* @morpheus (contributor)\\n* @neo (stack)\"}"
+    body = "{\"body\":\"**🦀 Requesting reviewers for this pull request:**\\n\\n* @morpheus (contributor)\\n* @neo (expert reviewer)\"}"
 
     with_mock HTTPoison, post: fn ^expected_url, ^body, _ -> {:ok, %HTTPoison.Response{status_code: 404}} end do
       assert :error ==
-               GitHubClient.create_request_comment("mirego/foo", 123, [%SelectedUser{username: "morpheus", type: "contributor"}, %SelectedUser{username: "neo", type: "stack"}])
+               GitHubClient.create_request_comment("mirego/foo", 123, [%SelectedUser{username: "morpheus", type: "contributor"}, %SelectedUser{username: "neo", type: "expert"}])
     end
   end
 
   test "create_request_comment/3 with erroneous response" do
     expected_url = "https://api.github.com/repos/mirego/foo/issues/123/comments"
-    body = "{\"body\":\"**🦀 Requesting reviewers for this pull request:**\\n\\n* @morpheus (contributor)\\n* @neo (stack)\"}"
+    body = "{\"body\":\"**🦀 Requesting reviewers for this pull request:**\\n\\n* @morpheus (contributor)\\n* @neo (expert reviewer)\"}"
 
     with_mock HTTPoison, post: fn ^expected_url, ^body, _ -> {:error, "error"} end do
       assert :error ==
-               GitHubClient.create_request_comment("mirego/foo", 123, [%SelectedUser{username: "morpheus", type: "contributor"}, %SelectedUser{username: "neo", type: "stack"}])
+               GitHubClient.create_request_comment("mirego/foo", 123, [%SelectedUser{username: "morpheus", type: "contributor"}, %SelectedUser{username: "neo", type: "expert"}])
     end
   end
 end

--- a/test/dispatch/repositories/request_comments_test.exs
+++ b/test/dispatch/repositories/request_comments_test.exs
@@ -6,9 +6,9 @@ defmodule Dispatch.Repositories.RequestCommentsTest do
 
   test "request_comment/1 return the correct message for every selected users" do
     selected_users = [
-      %SelectedUser{username: "user-1", type: "stack", metadata: %{stack: "elixir"}},
-      %SelectedUser{username: "user-2", type: "stack", metadata: %{stack: "graphql"}},
-      %SelectedUser{username: "user-3", type: "stack", metadata: %{anything: "anything"}},
+      %SelectedUser{username: "user-1", type: "expert", metadata: %{stack: "elixir"}},
+      %SelectedUser{username: "user-2", type: "expert", metadata: %{stack: "graphql"}},
+      %SelectedUser{username: "user-3", type: "expert", metadata: %{anything: "anything"}},
       %SelectedUser{username: "user-4", type: "contributor", metadata: %{recent_commit_count: 20, total_commit_count: 256}},
       %SelectedUser{username: "user-5", type: "contributor", metadata: %{anything: "anything"}},
       %SelectedUser{username: "user-6", type: "learner"},
@@ -19,17 +19,17 @@ defmodule Dispatch.Repositories.RequestCommentsTest do
     expected_message = """
     **🦀 Requesting reviewers for this pull request:**
 
-    * @user-1 (reviewer for the `elixir` stack)
-    * @user-2 (reviewer for the `graphql` stack)
-    * @user-3 (stack)
+    * @user-1 (expert reviewer for the `elixir` stack)
+    * @user-2 (expert reviewer for the `graphql` stack)
+    * @user-3 (expert reviewer)
     * @user-4 (contributor with `20` commits in the last 90 days and `256` commits overall)
     * @user-5 (contributor)
 
     **🦀 Mentionning users for this pull request:**
 
-    * @user-6 (learner)
-    * @user-7 (learner for the `elixir` stack)
-    * @user-8 (learner for the `graphql` stack)
+    * @user-6 (learner reviewer)
+    * @user-7 (learner reviewer for the `elixir` stack)
+    * @user-8 (learner reviewer for the `graphql` stack)
     """
 
     result = RequestComments.request_comment(selected_users)
@@ -38,14 +38,14 @@ defmodule Dispatch.Repositories.RequestCommentsTest do
 
   test "request_comment/1 return the correct message without learners" do
     selected_users = [
-      %SelectedUser{username: "user-1", type: "stack", metadata: %{stack: "elixir"}},
+      %SelectedUser{username: "user-1", type: "expert", metadata: %{stack: "elixir"}},
       %SelectedUser{username: "user-4", type: "contributor", metadata: %{recent_commit_count: 20, total_commit_count: 256}}
     ]
 
     expected_message = """
     **🦀 Requesting reviewers for this pull request:**
 
-    * @user-1 (reviewer for the `elixir` stack)
+    * @user-1 (expert reviewer for the `elixir` stack)
     * @user-4 (contributor with `20` commits in the last 90 days and `256` commits overall)
     """
 

--- a/test/dispatch_web/webhooks/controller_test.exs
+++ b/test/dispatch_web/webhooks/controller_test.exs
@@ -158,7 +158,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
                                      1,
                                      [
                                        %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 1, total_commit_count: 1}},
-                                       %SelectedUser{username: "biz", type: "stack", metadata: %{stack: "graphql"}}
+                                       %SelectedUser{username: "biz", type: "expert", metadata: %{stack: "graphql"}}
                                      ] ->
       :ok
     end)
@@ -166,7 +166,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
                                           1,
                                           [
                                             %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 1, total_commit_count: 1}},
-                                            %SelectedUser{username: "biz", type: "stack", metadata: %{stack: "graphql"}},
+                                            %SelectedUser{username: "biz", type: "expert", metadata: %{stack: "graphql"}},
                                             %SelectedUser{username: "pif", type: "learner", metadata: %{stack: "elixir"}}
                                           ] ->
       :ok
@@ -198,7 +198,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
                },
                %{
                  "metadata" => %{"stack" => "graphql"},
-                 "type" => "stack",
+                 "type" => "expert",
                  "username" => "biz"
                },
                %{
@@ -226,7 +226,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
                                      1,
                                      [
                                        %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 1, total_commit_count: 1}},
-                                       %SelectedUser{username: "ruby-master", type: "stack", metadata: %{stack: "ruby"}}
+                                       %SelectedUser{username: "ruby-master", type: "expert", metadata: %{stack: "ruby"}}
                                      ] ->
       :ok
     end)
@@ -234,7 +234,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
                                           1,
                                           [
                                             %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 1, total_commit_count: 1}},
-                                            %SelectedUser{username: "ruby-master", type: "stack", metadata: %{stack: "ruby"}},
+                                            %SelectedUser{username: "ruby-master", type: "expert", metadata: %{stack: "ruby"}},
                                             %SelectedUser{username: "ruby-learner", type: "learner", metadata: %{stack: "ruby"}}
                                           ] ->
       :ok
@@ -261,7 +261,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
                },
                %{
                  "metadata" => %{"stack" => "ruby"},
-                 "type" => "stack",
+                 "type" => "expert",
                  "username" => "ruby-master"
                },
                %{


### PR DESCRIPTION
We had a small inconsistency between how we represent “expert” and “learner” reviewers.

### Before
```elixir
%SelectedUser{metadata: %{stack: "graphql"}, type: "stack", username: "foo"}
%SelectedUser{metadata: %{stack: "graphql"}, type: "learner", username: "foo"}
```

### After
```elixir
%SelectedUser{metadata: %{stack: "graphql"}, type: "expert", username: "foo"}
%SelectedUser{metadata: %{stack: "graphql"}, type: "learner", username: "foo"}
```