### PR TITLE
Ignore Pull requests opened by bots

### DIFF
--- a/lib/dispatch_web/webhooks/controller.ex
+++ b/lib/dispatch_web/webhooks/controller.ex
@@ -5,6 +5,8 @@ defmodule DispatchWeb.Webhooks.Controller do
   def create(conn, %{"action" => "opened", "pull_request" => %{"title" => "WIP:" <> _}}), do: json(conn, %{success: true, noop: true})
   def create(conn, %{"action" => "opened", "pull_request" => %{"title" => "[WIP]" <> _}}), do: json(conn, %{success: true, noop: true})
 
+  def create(conn, %{"action" => "opened", "pull_request" => %{"user" => %{"type" => "Bot"}}}), do: json(conn, %{success: true, noop: true})
+
   def create(conn, %{"action" => "opened", "repository" => %{"owner" => %{"login" => repo_owner}}} = params) do
     github_organization_login = github_organization_login()
 

--- a/test/dispatch_web/webhooks/controller_test.exs
+++ b/test/dispatch_web/webhooks/controller_test.exs
@@ -49,6 +49,13 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
     assert json_response(conn, 200) == %{"success" => true, "noop" => true}
   end
 
+  test "POST /webhooks with pull request from bots", %{conn: conn} do
+    params = %{"stacks" => "elixir,graphql", "action" => "opened", "pull_request" => %{"user" => %{"type" => "Bot"}}}
+    conn = post(conn, "/webhooks", params)
+
+    assert json_response(conn, 200) == %{"success" => true, "noop" => true}
+  end
+
   test "POST /webhooks with pull request from other organization", %{conn: conn} do
     params = %{"stacks" => "elixir,graphql", "action" => "opened", "pull_request" => %{"title" => "Add new feature", "repo" => %{"login" => "ixmedia"}}}
     conn = post(conn, "/webhooks", params)


### PR DESCRIPTION
We recently enabled `dependabot` on our repositories. It has opened a lot of PRs and I think we should not assign any reviewers on those PRs.