### PR TITLE
Allow stacks with a dot in their name

### DIFF
--- a/lib/dispatch/dispatch.ex
+++ b/lib/dispatch/dispatch.ex
@@ -86,7 +86,7 @@ defmodule Dispatch do
   def extract_from_params(%{"pull_request" => %{"body" => body}} = params) do
     default_stacks = Map.get(params, "stacks", "")
 
-    ~r/#dispatch\/(\w+)/i
+    ~r/#dispatch\/([\w.]+)/i
     |> Regex.scan(body, capture: :all_but_first)
     |> (fn
           [] -> String.split(default_stacks, ",")

--- a/test/dispatch_test.exs
+++ b/test/dispatch_test.exs
@@ -268,11 +268,11 @@ defmodule DispatchTest do
 
     Also, there are no default stacks in the webhook URL.
 
-    #dispatch/hcl #dispatch/Ruby
+    #dispatch/hcl #dispatch/Ruby #dispatch/node.js
     """
 
     stacks = Dispatch.extract_from_params(%{"pull_request" => %{"body" => body}})
 
-    assert stacks == ["hcl", "ruby"]
+    assert stacks == ["hcl", "ruby", "node.js"]
   end
 end


### PR DESCRIPTION
When we declare the related stacks of a PR within it's description, the regex to extract those stacks didn't allow for a dot in it's name. 

When requesting reviewers for the stack `#dispatch/node.js`, the extracted stack name was `node`, not `node.js`. Since `node` didn't match any stacks within our config, it was ignored.

This change to the regex will a correctly capture `node.js` instead of just `node`.