### PR TITLE
Replace blacklist with blocklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## v1.1.0 (_In progress_)
+
+### 1. Features
+
+- _None_
+
+### 2. Bug fixes
+
+- _None_
+
+### 3. Breaking changes
+
+- `blacklist` is replaced with `blocklist`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - _None_
 
-### 3. Breaking changes
+### 3. Deprecations
 
 - `blacklist` is replaced with `blocklist`
+
+### 4. Breaking changes
+
+- _None_

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Draft pull requests or pull requests with a title that begins with `WIP `, `WIP:
 
 From time to time, it can be useful to pass some specific stacks for a single pull request that differ from the ones used in the Webhook URL. `#dispatch/<stack>` tags can be added to the pull request body and Dispatch will use them as stacks instead of the default ones (configured in the webhook URL).
 
-### Contributors blacklist
+### Contributors blocklist
 
-GitHub users listed in `blacklist` will never be requested for a review nor mentionned.
+GitHub users listed in `blocklist` will never be requested for a review nor mentionned.
 
 ### Learners
 
@@ -116,17 +116,17 @@ The `priv/scripts/ci-check.sh` script runs a few commands (tests, lint, etc.) to
 
 ## 🏗 Code & architecture
 
-### Experts, learners and blacklisted users
+### Experts, learners and blocklisted users
 
 The configuration file stored at `CONFIGURATION_FILE_URL` should contain a JSON object with three keys:
 
-* `blacklist`
+* `blocklist`
 * `experts`
 * `learners`
 
 ```json
 {
-  "blacklist": [
+  "blocklist": [
     {
       "username": "github_username"
     }

--- a/lib/dispatch/dispatch.ex
+++ b/lib/dispatch/dispatch.ex
@@ -9,7 +9,7 @@ defmodule Dispatch do
   alias Dispatch.Settings
   alias Dispatch.Utils.Normalization
 
-  defmodule BlacklistedUser do
+  defmodule BlocklistedUser do
     @enforce_keys [:username]
     @derive Jason.Encoder
     defstruct username: nil
@@ -37,7 +37,7 @@ defmodule Dispatch do
   Returns a list of usernames that should be request to review the pull request
   """
   def fetch_selected_users(repo, stacks, author_username, disable_learners \\ false) do
-    excluded_usernames = [author_username | Enum.map(Settings.blacklisted_users(), & &1.username)]
+    excluded_usernames = [author_username | Enum.map(Settings.blocklisted_users(), & &1.username)]
 
     # 1. Refresh settings
     Settings.refresh()

--- a/lib/dispatch/settings/client_behaviour.ex
+++ b/lib/dispatch/settings/client_behaviour.ex
@@ -1,5 +1,5 @@
 defmodule Dispatch.Settings.ClientBehaviour do
-  @callback blacklisted_users :: list(Dispatch.Settings.BlacklistedUser.t())
+  @callback blocklisted_users :: list(Dispatch.Settings.BlocklistedUser.t())
   @callback expert_users(String.t()) :: list(Dispatch.Settings.Expert.t())
   @callback learner_users(String.t()) :: list(Dispatch.Settings.Learner.t())
   @callback stacks :: list(String.t())

--- a/lib/dispatch/settings/json_static_file_client.ex
+++ b/lib/dispatch/settings/json_static_file_client.ex
@@ -62,7 +62,7 @@ defmodule Dispatch.Settings.JSONStaticFileClient do
     %State{
       learners: Map.get(configuration, "learners", %{}),
       experts: Map.get(configuration, "experts", %{}),
-      blocklist: Map.get(configuration, "blocklist", [])
+      blocklist: Map.get(configuration, "blocklist", Map.get(configuration, "blacklist", []))
     }
   end
 

--- a/lib/dispatch/settings/json_static_file_client.ex
+++ b/lib/dispatch/settings/json_static_file_client.ex
@@ -3,12 +3,12 @@ defmodule Dispatch.Settings.JSONStaticFileClient do
 
   @behaviour Dispatch.Settings.ClientBehaviour
 
-  alias Dispatch.{BlacklistedUser, Expert, Learner}
+  alias Dispatch.{BlocklistedUser, Expert, Learner}
   alias Dispatch.Settings.ClientBehaviour
 
   defmodule State do
-    @enforce_keys ~w(experts learners blacklist)a
-    defstruct experts: nil, learners: nil, blacklist: nil
+    @enforce_keys ~w(experts learners blocklist)a
+    defstruct experts: nil, learners: nil, blocklist: nil
   end
 
   def start_link do
@@ -34,10 +34,10 @@ defmodule Dispatch.Settings.JSONStaticFileClient do
   end
 
   @impl ClientBehaviour
-  def blacklisted_users do
+  def blocklisted_users do
     __MODULE__
-    |> Agent.get(& &1.blacklist)
-    |> Enum.map(&%BlacklistedUser{username: &1["username"]})
+    |> Agent.get(& &1.blocklist)
+    |> Enum.map(&%BlocklistedUser{username: &1["username"]})
   end
 
   @impl ClientBehaviour
@@ -62,7 +62,7 @@ defmodule Dispatch.Settings.JSONStaticFileClient do
     %State{
       learners: Map.get(configuration, "learners", %{}),
       experts: Map.get(configuration, "experts", %{}),
-      blacklist: Map.get(configuration, "blacklist", [])
+      blocklist: Map.get(configuration, "blocklist", [])
     }
   end
 

--- a/lib/dispatch/settings/settings.ex
+++ b/lib/dispatch/settings/settings.ex
@@ -1,7 +1,7 @@
 defmodule Dispatch.Settings do
   alias Dispatch.Expert
 
-  def blacklisted_users, do: client().blacklisted_users()
+  def blocklisted_users, do: client().blocklisted_users()
   def expert_users(stack), do: client().expert_users(stack)
   def learner_users(stack), do: client().learner_users(stack)
   def refresh, do: client().refresh()

--- a/test/dispatch/settings/json_static_file_client_test.exs
+++ b/test/dispatch/settings/json_static_file_client_test.exs
@@ -9,7 +9,7 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
     body = """
     {
       "learners": {},
-      "blacklist": {},
+      "blocklist": {},
       "experts": {}
     }
     """
@@ -33,7 +33,7 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
           }
         ]
       },
-      "blacklist": [],
+      "blocklist": [],
       "experts": {}
     }
     """
@@ -50,7 +50,7 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
     body = """
     {
       "learners": {},
-      "blacklist": [],
+      "blocklist": [],
       "experts": {
         "elixir": [
           {
@@ -69,11 +69,11 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
     end
   end
 
-  test "blacklist" do
+  test "blocklist" do
     body = """
     {
       "learners": {},
-      "blacklist": [
+      "blocklist": [
         {
           "username": "test"
         }
@@ -85,8 +85,8 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
     with_mock HTTPoison, get: fn _ -> {:ok, %HTTPoison.Response{status_code: 200, body: body}} end do
       Client.refresh()
 
-      users = Client.blacklisted_users()
-      assert users === [%Dispatch.BlacklistedUser{username: "test"}]
+      users = Client.blocklisted_users()
+      assert users === [%Dispatch.BlocklistedUser{username: "test"}]
     end
   end
 
@@ -97,7 +97,7 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
         "elixir": [],
         "javascript": []
       },
-      "blacklist": [],
+      "blocklist": [],
       "experts": {
         "javascript": [],
         "react": []
@@ -121,13 +121,13 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
       Client.refresh()
 
       stacks = Client.stacks()
-      blacklisted = Client.blacklisted_users()
+      blocklisted = Client.blocklisted_users()
       experts = Client.expert_users("elixir")
       learners = Client.learner_users("elixir")
 
       assert length(learners) === 0
       assert length(experts) === 0
-      assert length(blacklisted) === 0
+      assert length(blocklisted) === 0
       assert length(stacks) === 0
     end
   end

--- a/test/dispatch/settings/json_static_file_client_test.exs
+++ b/test/dispatch/settings/json_static_file_client_test.exs
@@ -90,6 +90,27 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
     end
   end
 
+  test "deprecated blacklist" do
+    body = """
+    {
+      "learners": {},
+      "blacklist": [
+        {
+          "username": "test"
+        }
+      ],
+      "experts": {}
+    }
+    """
+
+    with_mock HTTPoison, get: fn _ -> {:ok, %HTTPoison.Response{status_code: 200, body: body}} end do
+      Client.refresh()
+
+      users = Client.blocklisted_users()
+      assert users === [%Dispatch.BlocklistedUser{username: "test"}]
+    end
+  end
+
   test "stacks" do
     body = """
     {

--- a/test/dispatch_test.exs
+++ b/test/dispatch_test.exs
@@ -3,7 +3,7 @@ defmodule DispatchTest do
 
   import Mox
 
-  alias Dispatch.BlacklistedUser
+  alias Dispatch.BlocklistedUser
   alias Dispatch.Expert
   alias Dispatch.Learner
   alias Dispatch.SelectedUser
@@ -16,7 +16,7 @@ defmodule DispatchTest do
 
   setup :verify_on_exit!
 
-  test "with blacklisted, random expert and random stack user" do
+  test "with blocklisted, random expert and random stack user" do
     Dispatch.Repositories.MockClient
     |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
     |> expect(:fetch_contributors, fn "mirego/foo" ->
@@ -29,7 +29,7 @@ defmodule DispatchTest do
 
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
-    |> expect(:blacklisted_users, fn -> [%BlacklistedUser{username: "foo"}] end)
+    |> expect(:blocklisted_users, fn -> [%BlocklistedUser{username: "foo"}] end)
     |> expect(:expert_users, fn "elixir" -> [%Expert{username: "foo"}] end)
     |> expect(:expert_users, fn "graphql" -> [%Expert{username: "biz"}, %Expert{username: "foo"}] end)
     |> expect(:learner_users, fn "elixir" -> [] end)
@@ -53,7 +53,7 @@ defmodule DispatchTest do
            ]
   end
 
-  test "with blacklisted, random reviewer and random stack user in contributors" do
+  test "with blocklisted, random reviewer and random stack user in contributors" do
     Dispatch.Repositories.MockClient
     |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
     |> expect(:fetch_contributors, fn "mirego/foo" ->
@@ -66,7 +66,7 @@ defmodule DispatchTest do
 
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
-    |> expect(:blacklisted_users, fn -> [%BlacklistedUser{username: "foo"}] end)
+    |> expect(:blocklisted_users, fn -> [%BlocklistedUser{username: "foo"}] end)
     |> expect(:expert_users, fn "elixir" -> [%Expert{username: "foo"}] end)
     |> expect(:expert_users, fn "graphql" -> [%Expert{username: "bar"}, %Expert{username: "foo"}] end)
     |> expect(:learner_users, fn "elixir" -> [] end)
@@ -85,7 +85,7 @@ defmodule DispatchTest do
            ]
   end
 
-  test "with blacklisted and absent, random reviewer and random stack user" do
+  test "with blocklisted and absent, random reviewer and random stack user" do
     now = Timex.now()
 
     Dispatch.Repositories.MockClient
@@ -100,7 +100,7 @@ defmodule DispatchTest do
 
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
-    |> expect(:blacklisted_users, fn -> [%BlacklistedUser{username: "foo"}] end)
+    |> expect(:blocklisted_users, fn -> [%BlocklistedUser{username: "foo"}] end)
     |> expect(:expert_users, fn "elixir" -> [%Expert{username: "foo"}] end)
     |> expect(:expert_users, fn "graphql" -> [%Expert{username: "biz"}, %Expert{username: "omg"}] end)
     |> expect(:learner_users, fn "elixir" -> [] end)
@@ -127,7 +127,7 @@ defmodule DispatchTest do
            ]
   end
 
-  test "with blacklisted, random reviewer and no stacks" do
+  test "with blocklisted, random reviewer and no stacks" do
     Dispatch.Repositories.MockClient
     |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
     |> expect(:fetch_contributors, fn "mirego/foo" ->
@@ -140,7 +140,7 @@ defmodule DispatchTest do
 
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
-    |> expect(:blacklisted_users, fn -> [%BlacklistedUser{username: "foo"}] end)
+    |> expect(:blocklisted_users, fn -> [%BlocklistedUser{username: "foo"}] end)
 
     expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
 
@@ -155,7 +155,7 @@ defmodule DispatchTest do
            ]
   end
 
-  test "without blacklisted or stack users" do
+  test "without blocklisted or stack users" do
     Dispatch.Repositories.MockClient
     |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
     |> expect(:fetch_contributors, fn "mirego/foo" ->
@@ -167,7 +167,7 @@ defmodule DispatchTest do
 
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
-    |> expect(:blacklisted_users, fn -> [] end)
+    |> expect(:blocklisted_users, fn -> [] end)
     |> expect(:expert_users, fn "elixir" -> [] end)
     |> expect(:learner_users, fn "elixir" -> [] end)
 
@@ -191,7 +191,7 @@ defmodule DispatchTest do
 
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
-    |> expect(:blacklisted_users, fn -> [] end)
+    |> expect(:blocklisted_users, fn -> [] end)
     |> expect(:expert_users, fn "elixir" -> [] end)
     |> expect(:learner_users, fn "elixir" -> [] end)
 
@@ -202,14 +202,14 @@ defmodule DispatchTest do
     assert selected_users == []
   end
 
-  test "with blacklisted, 2 out of 3 requestable learners selected via exposure" do
+  test "with blocklisted, 2 out of 3 requestable learners selected via exposure" do
     Dispatch.Repositories.MockClient
     |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
     |> expect(:fetch_contributors, fn "mirego/foo" -> [] end)
 
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
-    |> expect(:blacklisted_users, fn -> [] end)
+    |> expect(:blocklisted_users, fn -> [] end)
     |> expect(:expert_users, fn "elixir" -> [] end)
     |> expect(:learner_users, fn "elixir" ->
       [

--- a/test/dispatch_web/webhooks/controller_test.exs
+++ b/test/dispatch_web/webhooks/controller_test.exs
@@ -3,7 +3,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
 
   import Mox
 
-  alias Dispatch.BlacklistedUser
+  alias Dispatch.BlocklistedUser
   alias Dispatch.Expert
   alias Dispatch.Learner
   alias Dispatch.SelectedUser
@@ -95,7 +95,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
 
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
-    |> expect(:blacklisted_users, fn -> [] end)
+    |> expect(:blocklisted_users, fn -> [] end)
     |> expect(:expert_users, fn "elixir" -> [] end)
 
     expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
@@ -134,7 +134,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
 
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
-    |> expect(:blacklisted_users, fn -> [] end)
+    |> expect(:blocklisted_users, fn -> [] end)
 
     expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
 
@@ -188,7 +188,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
 
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
-    |> expect(:blacklisted_users, fn -> [%BlacklistedUser{username: "foo"}] end)
+    |> expect(:blocklisted_users, fn -> [%BlocklistedUser{username: "foo"}] end)
     |> expect(:expert_users, fn "elixir" -> [%Expert{username: "foo"}] end)
     |> expect(:expert_users, fn "graphql" -> [%Expert{username: "biz"}, %Expert{username: "omg"}] end)
     |> expect(:learner_users, fn "elixir" -> [%Learner{username: "paf", exposure: 0}, %Learner{username: "pif", exposure: 1}] end)
@@ -256,7 +256,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
 
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
-    |> expect(:blacklisted_users, fn -> [%BlacklistedUser{username: "foo"}] end)
+    |> expect(:blocklisted_users, fn -> [%BlocklistedUser{username: "foo"}] end)
     |> expect(:expert_users, fn "ruby" -> [%Expert{username: "ruby-master"}] end)
     |> expect(:learner_users, fn "ruby" -> [%Learner{username: "ruby-learner", exposure: 1}] end)
 
@@ -304,7 +304,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
 
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
-    |> expect(:blacklisted_users, fn -> [] end)
+    |> expect(:blocklisted_users, fn -> [] end)
     |> expect(:expert_users, fn "elixir" -> [] end)
     |> expect(:expert_users, fn "graphql" -> [] end)
     |> expect(:learner_users, fn "elixir" -> [] end)
@@ -345,7 +345,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
 
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
-    |> expect(:blacklisted_users, fn -> [] end)
+    |> expect(:blocklisted_users, fn -> [] end)
 
     expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
 
@@ -374,7 +374,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
 
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
-    |> expect(:blacklisted_users, fn -> [] end)
+    |> expect(:blocklisted_users, fn -> [] end)
 
     expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
 


### PR DESCRIPTION
## 📖 Description

_Blacklist_  is a less and less accepted term in the open-source community. I suggest we use `blocklist` instead.

## 🦀 Dispatch

`#dispatch/elixir`