### PR TITLE
Replace experts with reviewers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### 3. Deprecations
 
-- `blacklist` is replaced with `blocklist`
+- `blacklist` is replaced with `blocklist` in the JSON static configuration file
+- `experts` is replaced with `reviewers` in the JSON static configuration file
 
 ### 4. Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The `priv/scripts/ci-check.sh` script runs a few commands (tests, lint, etc.) to
 The configuration file stored at `CONFIGURATION_FILE_URL` should contain a JSON object with three keys:
 
 * `blocklist`
-* `experts`
+* `reviewers`
 * `learners`
 
 ```json
@@ -131,7 +131,7 @@ The configuration file stored at `CONFIGURATION_FILE_URL` should contain a JSON 
       "username": "github_username"
     }
   ],
-  "experts": {
+  "reviewers": {
     "stack_name": [
       {
         "username": "github_username"

--- a/lib/dispatch/dispatch.ex
+++ b/lib/dispatch/dispatch.ex
@@ -15,7 +15,7 @@ defmodule Dispatch do
     defstruct username: nil
   end
 
-  defmodule Expert do
+  defmodule Reviewer do
     @enforce_keys [:username]
     @derive Jason.Encoder
     defstruct username: nil, type: nil, metadata: nil
@@ -54,15 +54,15 @@ defmodule Dispatch do
     contributors = Repositories.contributors(repo, requestable_usernames)
     requestable_usernames = update_requestable_usernames(requestable_usernames, Enum.map(contributors, & &1.username))
 
-    # 4. Update the pool and then select a random stack-skilled expert for each stack
-    stack_experts = Settings.experts(requestable_usernames, stacks)
+    # 4. Update the pool and then select a random stack-skilled reviewer for each stack
+    stack_reviewers = Settings.reviewers(requestable_usernames, stacks)
     requestable_usernames = update_requestable_usernames(requestable_usernames, Enum.map(contributors, & &1.username))
 
     # 5. Update the pool and then randomly add -learners as reviewers for each stack
     stack_learners = if disable_learners, do: [], else: Settings.learners(requestable_usernames, stacks)
 
     # 6. Map all selected users to SelectedUser struct
-    Enum.map(contributors ++ stack_experts ++ stack_learners, &struct(SelectedUser, Map.from_struct(&1)))
+    Enum.map(contributors ++ stack_reviewers ++ stack_learners, &struct(SelectedUser, Map.from_struct(&1)))
   end
 
   @doc """
@@ -99,7 +99,7 @@ defmodule Dispatch do
 
   def extract_from_params(_), do: []
 
-  def request_or_mention_reviewer?(%SelectedUser{type: type}) when type in ["contributor", "expert"], do: :request
+  def request_or_mention_reviewer?(%SelectedUser{type: type}) when type in ["contributor", "reviewer"], do: :request
   def request_or_mention_reviewer?(_), do: :mention
 
   defp update_requestable_usernames(requestable_usernames, reviewer_usernames) do

--- a/lib/dispatch/repositories/request_comments.ex
+++ b/lib/dispatch/repositories/request_comments.ex
@@ -16,15 +16,15 @@ defmodule Dispatch.Repositories.RequestComments do
   Given a list of 3 reviewers
 
   %{username: "John", type: "contributor", metadata: %{relevancy: "23/99"}}
-  %{username: "Jane", type: "expert", metadata: %{stack: "elixir"}}
-  %{username: "Joe", type: "expert", metadata: %{stack: "graphql"}}
+  %{username: "Jane", type: "reviewer", metadata: %{stack: "elixir"}}
+  %{username: "Joe", type: "reviewer", metadata: %{stack: "graphql"}}
   %{username: "Jerry", type: "learner"}
 
   So reviewers will be displayed like this:
 
   @John (contributor with 23% relevancy)
-  @Jane (expert reviewer for the elixir stack)
-  @Joe (expert reviewer for the graphql stack)
+  @Jane (reviewer for the elixir stack)
+  @Joe (reviewer for the graphql stack)
   @Jerry (learner reviewer)
   """
   def request_comment(reviewers) do
@@ -49,12 +49,12 @@ defmodule Dispatch.Repositories.RequestComments do
     "* @#{username} (contributor with `#{recent_commit_count}` commits in the last #{relevant_activity_days} days and `#{total_commit_count}` commits overall)\n"
   end
 
-  defp reviewer_line(%{username: username, type: "expert", metadata: %{stack: stack}}) do
-    "* @#{username} (expert reviewer for the `#{stack}` stack)\n"
+  defp reviewer_line(%{username: username, type: "reviewer", metadata: %{stack: stack}}) do
+    "* @#{username} (reviewer for the `#{stack}` stack)\n"
   end
 
   defp reviewer_line(%{username: username, type: "learner", metadata: %{stack: stack}}) do
-    "* @#{username} (learner reviewer for the `#{stack}` stack)\n"
+    "* @#{username} (learner for the `#{stack}` stack)\n"
   end
 
   defp reviewer_line(%{username: username, type: "contributor"}) do
@@ -62,6 +62,6 @@ defmodule Dispatch.Repositories.RequestComments do
   end
 
   defp reviewer_line(%{username: username, type: type}) do
-    "* @#{username} (#{type} reviewer)\n"
+    "* @#{username} (#{type})\n"
   end
 end

--- a/lib/dispatch/settings/client_behaviour.ex
+++ b/lib/dispatch/settings/client_behaviour.ex
@@ -1,6 +1,6 @@
 defmodule Dispatch.Settings.ClientBehaviour do
   @callback blocklisted_users :: list(Dispatch.Settings.BlocklistedUser.t())
-  @callback expert_users(String.t()) :: list(Dispatch.Settings.Expert.t())
+  @callback reviewer_users(String.t()) :: list(Dispatch.Settings.Reviewer.t())
   @callback learner_users(String.t()) :: list(Dispatch.Settings.Learner.t())
   @callback stacks :: list(String.t())
   @callback refresh :: atom()

--- a/lib/dispatch/settings/json_static_file_client.ex
+++ b/lib/dispatch/settings/json_static_file_client.ex
@@ -3,12 +3,12 @@ defmodule Dispatch.Settings.JSONStaticFileClient do
 
   @behaviour Dispatch.Settings.ClientBehaviour
 
-  alias Dispatch.{BlocklistedUser, Expert, Learner}
+  alias Dispatch.{BlocklistedUser, Learner, Reviewer}
   alias Dispatch.Settings.ClientBehaviour
 
   defmodule State do
-    @enforce_keys ~w(experts learners blocklist)a
-    defstruct experts: nil, learners: nil, blocklist: nil
+    @enforce_keys ~w(reviewers learners blocklist)a
+    defstruct reviewers: nil, learners: nil, blocklist: nil
   end
 
   def start_link do
@@ -18,11 +18,11 @@ defmodule Dispatch.Settings.JSONStaticFileClient do
   end
 
   @impl ClientBehaviour
-  def expert_users(stack) do
+  def reviewer_users(stack) do
     __MODULE__
-    |> Agent.get(& &1.experts)
+    |> Agent.get(& &1.reviewers)
     |> Map.get(stack, [])
-    |> Enum.map(&%Expert{username: &1["username"]})
+    |> Enum.map(&%Reviewer{username: &1["username"]})
   end
 
   @impl ClientBehaviour
@@ -42,10 +42,10 @@ defmodule Dispatch.Settings.JSONStaticFileClient do
 
   @impl ClientBehaviour
   def stacks do
-    experts = Agent.get(__MODULE__, & &1.experts)
+    reviewers = Agent.get(__MODULE__, & &1.reviewers)
     learners = Agent.get(__MODULE__, & &1.learners)
 
-    experts
+    reviewers
     |> Map.merge(learners)
     |> Map.keys()
   end
@@ -61,7 +61,7 @@ defmodule Dispatch.Settings.JSONStaticFileClient do
 
     %State{
       learners: Map.get(configuration, "learners", %{}),
-      experts: Map.get(configuration, "experts", %{}),
+      reviewers: Map.get(configuration, "reviewers", Map.get(configuration, "experts", %{})),
       blocklist: Map.get(configuration, "blocklist", Map.get(configuration, "blacklist", []))
     }
   end

--- a/test/dispatch/repositories/github_client_test.exs
+++ b/test/dispatch/repositories/github_client_test.exs
@@ -253,31 +253,31 @@ defmodule Dispatch.Repositories.GitHubClientTest do
 
   test "create_request_comment/3 with successful response" do
     expected_url = "https://api.github.com/repos/mirego/foo/issues/123/comments"
-    body = "{\"body\":\"**🦀 Requesting reviewers for this pull request:**\\n\\n* @morpheus (contributor)\\n* @neo (expert reviewer)\"}"
+    body = "{\"body\":\"**🦀 Requesting reviewers for this pull request:**\\n\\n* @morpheus (contributor)\\n* @neo (reviewer)\"}"
 
     with_mock HTTPoison, post: fn ^expected_url, ^body, _ -> {:ok, %HTTPoison.Response{status_code: 201}} end do
       assert :ok ==
-               GitHubClient.create_request_comment("mirego/foo", 123, [%SelectedUser{username: "morpheus", type: "contributor"}, %SelectedUser{username: "neo", type: "expert"}])
+               GitHubClient.create_request_comment("mirego/foo", 123, [%SelectedUser{username: "morpheus", type: "contributor"}, %SelectedUser{username: "neo", type: "reviewer"}])
     end
   end
 
   test "create_request_comment/3 with non-successful response" do
     expected_url = "https://api.github.com/repos/mirego/foo/issues/123/comments"
-    body = "{\"body\":\"**🦀 Requesting reviewers for this pull request:**\\n\\n* @morpheus (contributor)\\n* @neo (expert reviewer)\"}"
+    body = "{\"body\":\"**🦀 Requesting reviewers for this pull request:**\\n\\n* @morpheus (contributor)\\n* @neo (reviewer)\"}"
 
     with_mock HTTPoison, post: fn ^expected_url, ^body, _ -> {:ok, %HTTPoison.Response{status_code: 404}} end do
       assert :error ==
-               GitHubClient.create_request_comment("mirego/foo", 123, [%SelectedUser{username: "morpheus", type: "contributor"}, %SelectedUser{username: "neo", type: "expert"}])
+               GitHubClient.create_request_comment("mirego/foo", 123, [%SelectedUser{username: "morpheus", type: "contributor"}, %SelectedUser{username: "neo", type: "reviewer"}])
     end
   end
 
   test "create_request_comment/3 with erroneous response" do
     expected_url = "https://api.github.com/repos/mirego/foo/issues/123/comments"
-    body = "{\"body\":\"**🦀 Requesting reviewers for this pull request:**\\n\\n* @morpheus (contributor)\\n* @neo (expert reviewer)\"}"
+    body = "{\"body\":\"**🦀 Requesting reviewers for this pull request:**\\n\\n* @morpheus (contributor)\\n* @neo (reviewer)\"}"
 
     with_mock HTTPoison, post: fn ^expected_url, ^body, _ -> {:error, "error"} end do
       assert :error ==
-               GitHubClient.create_request_comment("mirego/foo", 123, [%SelectedUser{username: "morpheus", type: "contributor"}, %SelectedUser{username: "neo", type: "expert"}])
+               GitHubClient.create_request_comment("mirego/foo", 123, [%SelectedUser{username: "morpheus", type: "contributor"}, %SelectedUser{username: "neo", type: "reviewer"}])
     end
   end
 end

--- a/test/dispatch/repositories/request_comments_test.exs
+++ b/test/dispatch/repositories/request_comments_test.exs
@@ -6,9 +6,9 @@ defmodule Dispatch.Repositories.RequestCommentsTest do
 
   test "request_comment/1 return the correct message for every selected users" do
     selected_users = [
-      %SelectedUser{username: "user-1", type: "expert", metadata: %{stack: "elixir"}},
-      %SelectedUser{username: "user-2", type: "expert", metadata: %{stack: "graphql"}},
-      %SelectedUser{username: "user-3", type: "expert", metadata: %{anything: "anything"}},
+      %SelectedUser{username: "user-1", type: "reviewer", metadata: %{stack: "elixir"}},
+      %SelectedUser{username: "user-2", type: "reviewer", metadata: %{stack: "graphql"}},
+      %SelectedUser{username: "user-3", type: "reviewer", metadata: %{anything: "anything"}},
       %SelectedUser{username: "user-4", type: "contributor", metadata: %{recent_commit_count: 20, total_commit_count: 256}},
       %SelectedUser{username: "user-5", type: "contributor", metadata: %{anything: "anything"}},
       %SelectedUser{username: "user-6", type: "learner"},
@@ -19,17 +19,17 @@ defmodule Dispatch.Repositories.RequestCommentsTest do
     expected_message = """
     **🦀 Requesting reviewers for this pull request:**
 
-    * @user-1 (expert reviewer for the `elixir` stack)
-    * @user-2 (expert reviewer for the `graphql` stack)
-    * @user-3 (expert reviewer)
+    * @user-1 (reviewer for the `elixir` stack)
+    * @user-2 (reviewer for the `graphql` stack)
+    * @user-3 (reviewer)
     * @user-4 (contributor with `20` commits in the last 90 days and `256` commits overall)
     * @user-5 (contributor)
 
     **🦀 Mentionning users for this pull request:**
 
-    * @user-6 (learner reviewer)
-    * @user-7 (learner reviewer for the `elixir` stack)
-    * @user-8 (learner reviewer for the `graphql` stack)
+    * @user-6 (learner)
+    * @user-7 (learner for the `elixir` stack)
+    * @user-8 (learner for the `graphql` stack)
     """
 
     result = RequestComments.request_comment(selected_users)
@@ -38,14 +38,14 @@ defmodule Dispatch.Repositories.RequestCommentsTest do
 
   test "request_comment/1 return the correct message without learners" do
     selected_users = [
-      %SelectedUser{username: "user-1", type: "expert", metadata: %{stack: "elixir"}},
+      %SelectedUser{username: "user-1", type: "reviewer", metadata: %{stack: "elixir"}},
       %SelectedUser{username: "user-4", type: "contributor", metadata: %{recent_commit_count: 20, total_commit_count: 256}}
     ]
 
     expected_message = """
     **🦀 Requesting reviewers for this pull request:**
 
-    * @user-1 (expert reviewer for the `elixir` stack)
+    * @user-1 (reviewer for the `elixir` stack)
     * @user-4 (contributor with `20` commits in the last 90 days and `256` commits overall)
     """
 

--- a/test/dispatch/settings/json_static_file_client_test.exs
+++ b/test/dispatch/settings/json_static_file_client_test.exs
@@ -10,7 +10,7 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
     {
       "learners": {},
       "blocklist": {},
-      "experts": {}
+      "reviewers": {}
     }
     """
 
@@ -34,7 +34,7 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
         ]
       },
       "blocklist": [],
-      "experts": {}
+      "reviewers": {}
     }
     """
 
@@ -46,7 +46,30 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
     end
   end
 
-  test "stack experts" do
+  test "stack reviewers" do
+    body = """
+    {
+      "learners": {},
+      "blocklist": [],
+      "reviewers": {
+        "elixir": [
+          {
+            "username": "test"
+          }
+        ]
+      }
+    }
+    """
+
+    with_mock HTTPoison, get: fn _ -> {:ok, %HTTPoison.Response{status_code: 200, body: body}} end do
+      Client.refresh()
+
+      users = Client.reviewer_users("elixir")
+      assert users === [%Dispatch.Reviewer{username: "test"}]
+    end
+  end
+
+  test "deprecated stack experts" do
     body = """
     {
       "learners": {},
@@ -64,8 +87,8 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
     with_mock HTTPoison, get: fn _ -> {:ok, %HTTPoison.Response{status_code: 200, body: body}} end do
       Client.refresh()
 
-      users = Client.expert_users("elixir")
-      assert users === [%Dispatch.Expert{username: "test"}]
+      users = Client.reviewer_users("elixir")
+      assert users === [%Dispatch.Reviewer{username: "test"}]
     end
   end
 
@@ -78,7 +101,7 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
           "username": "test"
         }
       ],
-      "experts": {}
+      "reviewers": {}
     }
     """
 
@@ -99,7 +122,7 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
           "username": "test"
         }
       ],
-      "experts": {}
+      "reviewers": {}
     }
     """
 
@@ -119,7 +142,7 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
         "javascript": []
       },
       "blocklist": [],
-      "experts": {
+      "reviewers": {
         "javascript": [],
         "react": []
       }
@@ -143,11 +166,11 @@ defmodule Dispatch.Settings.JSONStaticFileClientTest do
 
       stacks = Client.stacks()
       blocklisted = Client.blocklisted_users()
-      experts = Client.expert_users("elixir")
+      reviewers = Client.reviewer_users("elixir")
       learners = Client.learner_users("elixir")
 
       assert length(learners) === 0
-      assert length(experts) === 0
+      assert length(reviewers) === 0
       assert length(blocklisted) === 0
       assert length(stacks) === 0
     end

--- a/test/dispatch_test.exs
+++ b/test/dispatch_test.exs
@@ -4,8 +4,8 @@ defmodule DispatchTest do
   import Mox
 
   alias Dispatch.BlocklistedUser
-  alias Dispatch.Expert
   alias Dispatch.Learner
+  alias Dispatch.Reviewer
   alias Dispatch.SelectedUser
 
   alias Dispatch.Repositories.Contributor
@@ -16,7 +16,7 @@ defmodule DispatchTest do
 
   setup :verify_on_exit!
 
-  test "with blocklisted, random expert and random stack user" do
+  test "with blocklisted, random reviewer and random stack user" do
     Dispatch.Repositories.MockClient
     |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
     |> expect(:fetch_contributors, fn "mirego/foo" ->
@@ -30,8 +30,8 @@ defmodule DispatchTest do
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
     |> expect(:blocklisted_users, fn -> [%BlocklistedUser{username: "foo"}] end)
-    |> expect(:expert_users, fn "elixir" -> [%Expert{username: "foo"}] end)
-    |> expect(:expert_users, fn "graphql" -> [%Expert{username: "biz"}, %Expert{username: "foo"}] end)
+    |> expect(:reviewer_users, fn "elixir" -> [%Reviewer{username: "foo"}] end)
+    |> expect(:reviewer_users, fn "graphql" -> [%Reviewer{username: "biz"}, %Reviewer{username: "foo"}] end)
     |> expect(:learner_users, fn "elixir" -> [] end)
     |> expect(:learner_users, fn "graphql" -> [] end)
 
@@ -47,7 +47,7 @@ defmodule DispatchTest do
              },
              %SelectedUser{
                metadata: %{stack: "graphql"},
-               type: "expert",
+               type: "reviewer",
                username: "biz"
              }
            ]
@@ -67,8 +67,8 @@ defmodule DispatchTest do
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
     |> expect(:blocklisted_users, fn -> [%BlocklistedUser{username: "foo"}] end)
-    |> expect(:expert_users, fn "elixir" -> [%Expert{username: "foo"}] end)
-    |> expect(:expert_users, fn "graphql" -> [%Expert{username: "bar"}, %Expert{username: "foo"}] end)
+    |> expect(:reviewer_users, fn "elixir" -> [%Reviewer{username: "foo"}] end)
+    |> expect(:reviewer_users, fn "graphql" -> [%Reviewer{username: "bar"}, %Reviewer{username: "foo"}] end)
     |> expect(:learner_users, fn "elixir" -> [] end)
     |> expect(:learner_users, fn "graphql" -> [] end)
 
@@ -101,8 +101,8 @@ defmodule DispatchTest do
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
     |> expect(:blocklisted_users, fn -> [%BlocklistedUser{username: "foo"}] end)
-    |> expect(:expert_users, fn "elixir" -> [%Expert{username: "foo"}] end)
-    |> expect(:expert_users, fn "graphql" -> [%Expert{username: "biz"}, %Expert{username: "omg"}] end)
+    |> expect(:reviewer_users, fn "elixir" -> [%Reviewer{username: "foo"}] end)
+    |> expect(:reviewer_users, fn "graphql" -> [%Reviewer{username: "biz"}, %Reviewer{username: "omg"}] end)
     |> expect(:learner_users, fn "elixir" -> [] end)
     |> expect(:learner_users, fn "graphql" -> [] end)
 
@@ -168,7 +168,7 @@ defmodule DispatchTest do
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
     |> expect(:blocklisted_users, fn -> [] end)
-    |> expect(:expert_users, fn "elixir" -> [] end)
+    |> expect(:reviewer_users, fn "elixir" -> [] end)
     |> expect(:learner_users, fn "elixir" -> [] end)
 
     expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
@@ -192,7 +192,7 @@ defmodule DispatchTest do
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
     |> expect(:blocklisted_users, fn -> [] end)
-    |> expect(:expert_users, fn "elixir" -> [] end)
+    |> expect(:reviewer_users, fn "elixir" -> [] end)
     |> expect(:learner_users, fn "elixir" -> [] end)
 
     expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
@@ -210,7 +210,7 @@ defmodule DispatchTest do
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
     |> expect(:blocklisted_users, fn -> [] end)
-    |> expect(:expert_users, fn "elixir" -> [] end)
+    |> expect(:reviewer_users, fn "elixir" -> [] end)
     |> expect(:learner_users, fn "elixir" ->
       [
         %Learner{username: "foo", exposure: 1},

--- a/test/dispatch_web/webhooks/controller_test.exs
+++ b/test/dispatch_web/webhooks/controller_test.exs
@@ -4,8 +4,8 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
   import Mox
 
   alias Dispatch.BlocklistedUser
-  alias Dispatch.Expert
   alias Dispatch.Learner
+  alias Dispatch.Reviewer
   alias Dispatch.SelectedUser
 
   alias Dispatch.Repositories.Contributor
@@ -96,7 +96,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
     |> expect(:blocklisted_users, fn -> [] end)
-    |> expect(:expert_users, fn "elixir" -> [] end)
+    |> expect(:reviewer_users, fn "elixir" -> [] end)
 
     expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
 
@@ -172,7 +172,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
                                      1,
                                      [
                                        %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 1, total_commit_count: 1}},
-                                       %SelectedUser{username: "biz", type: "expert", metadata: %{stack: "graphql"}}
+                                       %SelectedUser{username: "biz", type: "reviewer", metadata: %{stack: "graphql"}}
                                      ] ->
       :ok
     end)
@@ -180,7 +180,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
                                           1,
                                           [
                                             %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 1, total_commit_count: 1}},
-                                            %SelectedUser{username: "biz", type: "expert", metadata: %{stack: "graphql"}},
+                                            %SelectedUser{username: "biz", type: "reviewer", metadata: %{stack: "graphql"}},
                                             %SelectedUser{username: "pif", type: "learner", metadata: %{stack: "elixir"}}
                                           ] ->
       :ok
@@ -189,8 +189,8 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
     |> expect(:blocklisted_users, fn -> [%BlocklistedUser{username: "foo"}] end)
-    |> expect(:expert_users, fn "elixir" -> [%Expert{username: "foo"}] end)
-    |> expect(:expert_users, fn "graphql" -> [%Expert{username: "biz"}, %Expert{username: "omg"}] end)
+    |> expect(:reviewer_users, fn "elixir" -> [%Reviewer{username: "foo"}] end)
+    |> expect(:reviewer_users, fn "graphql" -> [%Reviewer{username: "biz"}, %Reviewer{username: "omg"}] end)
     |> expect(:learner_users, fn "elixir" -> [%Learner{username: "paf", exposure: 0}, %Learner{username: "pif", exposure: 1}] end)
     |> expect(:learner_users, fn "graphql" -> [] end)
 
@@ -212,7 +212,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
                },
                %{
                  "metadata" => %{"stack" => "graphql"},
-                 "type" => "expert",
+                 "type" => "reviewer",
                  "username" => "biz"
                },
                %{
@@ -240,7 +240,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
                                      1,
                                      [
                                        %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 1, total_commit_count: 1}},
-                                       %SelectedUser{username: "ruby-master", type: "expert", metadata: %{stack: "ruby"}}
+                                       %SelectedUser{username: "ruby-master", type: "reviewer", metadata: %{stack: "ruby"}}
                                      ] ->
       :ok
     end)
@@ -248,7 +248,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
                                           1,
                                           [
                                             %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 1, total_commit_count: 1}},
-                                            %SelectedUser{username: "ruby-master", type: "expert", metadata: %{stack: "ruby"}},
+                                            %SelectedUser{username: "ruby-master", type: "reviewer", metadata: %{stack: "ruby"}},
                                             %SelectedUser{username: "ruby-learner", type: "learner", metadata: %{stack: "ruby"}}
                                           ] ->
       :ok
@@ -257,7 +257,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
     |> expect(:blocklisted_users, fn -> [%BlocklistedUser{username: "foo"}] end)
-    |> expect(:expert_users, fn "ruby" -> [%Expert{username: "ruby-master"}] end)
+    |> expect(:reviewer_users, fn "ruby" -> [%Reviewer{username: "ruby-master"}] end)
     |> expect(:learner_users, fn "ruby" -> [%Learner{username: "ruby-learner", exposure: 1}] end)
 
     expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
@@ -275,7 +275,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
                },
                %{
                  "metadata" => %{"stack" => "ruby"},
-                 "type" => "expert",
+                 "type" => "reviewer",
                  "username" => "ruby-master"
                },
                %{
@@ -305,8 +305,8 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
     Dispatch.Settings.MockClient
     |> expect(:refresh, fn -> true end)
     |> expect(:blocklisted_users, fn -> [] end)
-    |> expect(:expert_users, fn "elixir" -> [] end)
-    |> expect(:expert_users, fn "graphql" -> [] end)
+    |> expect(:reviewer_users, fn "elixir" -> [] end)
+    |> expect(:reviewer_users, fn "graphql" -> [] end)
     |> expect(:learner_users, fn "elixir" -> [] end)
     |> expect(:learner_users, fn "graphql" -> [] end)
 


### PR DESCRIPTION
## 📖 Description

The term _expert_ was too strong and was scaring potential reviewers. You don’t need to be an expert to review some code, you just need to know about it and care.

## 🦀 Dispatch

`#dispatch/elixir`