### PR TITLE
Add more flexibility in absent username extraction

### DIFF
--- a/lib/dispatch/absences/absences.ex
+++ b/lib/dispatch/absences/absences.ex
@@ -11,8 +11,13 @@ defmodule Dispatch.Absences do
 
   defp absent_right_now?(%{start: starts, end: ends}), do: Timex.between?(Timex.now(), starts, ends, inclusive: true)
 
-  defp extract_fullname(%ExIcal.Event{summary: " Out of Office - " <> fullname}), do: Normalization.normalize(fullname)
-  defp extract_fullname(%ExIcal.Event{summary: "Out of Office - " <> fullname}), do: Normalization.normalize(fullname)
+  defp extract_fullname(%ExIcal.Event{summary: summary}) when is_binary(summary) do
+    summary
+    |> String.split(" - ")
+    |> List.last()
+    |> Normalization.normalize()
+  end
+
   defp extract_fullname(_), do: nil
 
   defp client, do: Application.get_env(:dispatch, Dispatch)[:absences_client]

--- a/test/dispatch/absences_test.exs
+++ b/test/dispatch/absences_test.exs
@@ -15,17 +15,17 @@ defmodule Dispatch.AbsencesTest do
       %ExIcal.Event{
         start: Timex.subtract(now, Duration.from_minutes(60)),
         end: Timex.add(now, Duration.from_minutes(60)),
-        summary: " Out of Office - supaidaman"
+        summary: "Out of Office - supaidaman"
       },
       %ExIcal.Event{
         start: Timex.subtract(now, Duration.from_days(1)),
         end: Timex.add(now, Duration.from_days(1)),
-        summary: "Out of Office - Swamp Thing"
+        summary: "Foo - Bar - Swamp Thing"
       },
       %ExIcal.Event{
         start: Timex.add(now, Duration.from_days(7)),
         end: Timex.add(now, Duration.from_days(14)),
-        summary: " Out of Office - Not absent"
+        summary: "Maternity Leave - Not absent"
       }
     ]
 
@@ -46,6 +46,11 @@ defmodule Dispatch.AbsencesTest do
         summary: " Out of Office - John Doe"
       },
       %ExIcal.Event{
+        start: Timex.subtract(now, Duration.from_minutes(60)),
+        end: Timex.add(now, Duration.from_minutes(60)),
+        summary: "Vacation - Jane Smith"
+      },
+      %ExIcal.Event{
         start: Timex.subtract(now, Duration.from_days(1)),
         end: Timex.add(now, Duration.from_days(1)),
         summary: nil
@@ -61,7 +66,7 @@ defmodule Dispatch.AbsencesTest do
 
     results = Absences.absent_fullnames()
 
-    assert results == ["john doe"]
+    assert results == ["john doe", "jane smith"]
   end
 
   test "absents/0 return empty list on no absents" do


### PR DESCRIPTION
## 📖 Description and reason

Recently, Absence.io changed how it exposes absences as calendar events. Previously, each event title was formatted like this:

```
Out of Office - $NAME
```

but now the absence _type_ is used as the prefix instead of a generic one, so we have:

```
Vacation - $NAME
Maternity Leave - $NAME
etc.
```

We want to support all of them 🙂

## 👷 Work done

#### Tasks

- [x] Remove the hardcoded `Out of Office` prefix and use only the last part of the title as the name
- [x] Update test suite

## 🦀 Dispatch

`#dispatch/elixir`
