### PR TITLE
Add possibility to specify a minimum_contributor_count via the Webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ Everything is done via a simple GitHub webhook:
 
 #### Webhook query string parameters
 
-| Parameter          | Default value | Description                                                        |
-|--------------------|---------------|--------------------------------------------------------------------|
-| `stacks`           | `""`          | Comma-separated values of project’s stacks (e.g. `elixir,graphql`) |
-| `disable_learners` | `false`       | Disable _learners_ for this repository                             |
+| Parameter                    | Default value     | Description                                                        |
+|------------------------------|-------------------|--------------------------------------------------------------------|
+| `stacks`                     | `""`              | Comma-separated values of project’s stacks (e.g. `elixir,graphql`) |
+| `disable_learners`           | `false`           | Disable _learners_ for this repository                             |
+| `minimum_contributors_count` | 1                 | Number of contributors to select                                   |
 
 ### Features
 
@@ -48,7 +49,7 @@ Everything is done via a simple GitHub webhook:
 
 When a pull request is opened, Dispatch selects a list of users that will be requested for a review:
 
-* One recent repository contributor
+* One or many recent repository contributor
 * One reviewer _per stack_
 * One or many learners _per stack_ (who will only be mentionned in the request comment)
 

--- a/lib/dispatch/dispatch.ex
+++ b/lib/dispatch/dispatch.ex
@@ -36,7 +36,10 @@ defmodule Dispatch do
   @doc """
   Returns a list of usernames that should be request to review the pull request
   """
-  def fetch_selected_users(repo, stacks, author_username, disable_learners \\ false) do
+  def fetch_selected_users(repo, stacks, author_username, opts \\ []) do
+    disable_learners = Keyword.get(opts, :disable_learners, false)
+    minimum_contributor_count = Keyword.get(opts, :minimum_contributor_count, 1) || 1
+
     excluded_usernames = [author_username | Enum.map(Settings.blocklisted_users(), & &1.username)]
 
     # 1. Refresh settings
@@ -51,7 +54,7 @@ defmodule Dispatch do
       |> Kernel.--(excluded_usernames)
 
     # 3. Select relevant contributors from it
-    contributors = Repositories.contributors(repo, requestable_usernames)
+    contributors = Repositories.contributors(repo, requestable_usernames, minimum_contributor_count)
     requestable_usernames = update_requestable_usernames(requestable_usernames, Enum.map(contributors, & &1.username))
 
     # 4. Update the pool and then select a random stack-skilled reviewer for each stack

--- a/lib/dispatch/repositories/repositories.ex
+++ b/lib/dispatch/repositories/repositories.ex
@@ -15,11 +15,28 @@ defmodule Dispatch.Repositories do
     client().fetch_requestable_users(repo)
   end
 
-  def contributors(repo, requestable_usernames) do
-    repo
-    |> client().fetch_contributors()
-    |> Enum.filter(&Enum.member?(requestable_usernames, &1.username))
-    |> Contributors.select()
+  def contributors(repo, requestable_usernames, count \\ 1) do
+    requestable_contributors =
+      repo
+      |> client().fetch_contributors()
+      |> Enum.filter(&Enum.member?(requestable_usernames, &1.username))
+
+    {_, selected_contributors} =
+      Enum.reduce_while(1..count, {requestable_contributors, []}, fn index, {available_contributors, selected_contributors} ->
+        if Enum.empty?(available_contributors) do
+          {:halt, {available_contributors, selected_contributors}}
+        else
+          [selected_contributor | _] = Contributors.select(available_contributors)
+
+          {:cont,
+           {
+             Enum.reject(available_contributors, &(&1.username === selected_contributor.username)),
+             selected_contributors ++ [selected_contributor]
+           }}
+        end
+      end)
+
+    selected_contributors
   end
 
   def request_reviewers(repo, pull_request_number, reviewers) do

--- a/lib/dispatch_web/webhooks/controller.ex
+++ b/lib/dispatch_web/webhooks/controller.ex
@@ -26,10 +26,11 @@ defmodule DispatchWeb.Webhooks.Controller do
     pull_request_number = get_in(params, ["number"])
     author = get_in(params, ["pull_request", "user", "login"])
     repo = get_in(params, ["repository", "full_name"])
+    minimum_contributor_count = get_in(params, ["minimum_contributor_count"])
 
     stacks = Dispatch.extract_from_params(params)
     disable_learners = string_to_boolean(Map.get(params, "disable_learners"))
-    selected_users = Dispatch.fetch_selected_users(repo, stacks, author, disable_learners)
+    selected_users = Dispatch.fetch_selected_users(repo, stacks, author, disable_learners: disable_learners, minimum_contributor_count: minimum_contributor_count)
 
     repo
     |> Dispatch.request_reviewers(pull_request_number, selected_users)

--- a/test/dispatch_web/webhooks/controller_test.exs
+++ b/test/dispatch_web/webhooks/controller_test.exs
@@ -2,6 +2,7 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
   use DispatchWeb.ConnCase
 
   import Mox
+  import Mock
 
   alias Dispatch.BlocklistedUser
   alias Dispatch.Learner
@@ -10,6 +11,8 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
 
   alias Dispatch.Repositories.Contributor
   alias Dispatch.Repositories.User
+
+  alias Dispatch.Utils.Random
 
   @requestable_users [
     %User{username: "foo", fullname: "foo"},
@@ -21,7 +24,8 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
     %User{username: "ruby-learner", fullname: "The Ruby Learner"}
   ]
   @contributors [
-    %Contributor{username: "bar", relevancy: 1, recent_commit_count: 1, total_commit_count: 1},
+    %Contributor{username: "bar", relevancy: 2, recent_commit_count: 2, total_commit_count: 2},
+    %Contributor{username: "biz", relevancy: 1, recent_commit_count: 1, total_commit_count: 1},
     %Contributor{username: "baz", relevancy: 0, recent_commit_count: 1, total_commit_count: 1},
     %Contributor{username: "omg", relevancy: 0, recent_commit_count: 1, total_commit_count: 1}
   ]
@@ -87,35 +91,40 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
       "pull_request" => %{"user" => %{"login" => "remiprev"}, "body" => "Foo"}
     }
 
-    Dispatch.Repositories.MockClient
-    |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
-    |> expect(:fetch_contributors, fn "mirego/foo" -> @contributors end)
-    |> expect(:request_reviewers, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :ok end)
-    |> expect(:create_request_comment, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :ok end)
+    with_mock Random,
+      uniform: fn
+        3 -> 1
+      end do
+      Dispatch.Repositories.MockClient
+      |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
+      |> expect(:fetch_contributors, fn "mirego/foo" -> @contributors end)
+      |> expect(:request_reviewers, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :ok end)
+      |> expect(:create_request_comment, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :ok end)
 
-    Dispatch.Settings.MockClient
-    |> expect(:refresh, fn -> true end)
-    |> expect(:blocklisted_users, fn -> [] end)
-    |> expect(:reviewer_users, fn "elixir" -> [] end)
+      Dispatch.Settings.MockClient
+      |> expect(:refresh, fn -> true end)
+      |> expect(:blocklisted_users, fn -> [] end)
+      |> expect(:reviewer_users, fn "elixir" -> [] end)
 
-    expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
+      expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
 
-    conn = post(conn, "/webhooks", params)
+      conn = post(conn, "/webhooks", params)
 
-    assert json_response(conn, 200) == %{
-             "success" => true,
-             "noop" => false,
-             "reviewers" => [
-               %{
-                 "metadata" => %{
-                   "recent_commit_count" => 1,
-                   "total_commit_count" => 1
-                 },
-                 "type" => "contributor",
-                 "username" => "bar"
-               }
-             ]
-           }
+      assert json_response(conn, 200) == %{
+               "success" => true,
+               "noop" => false,
+               "reviewers" => [
+                 %{
+                   "metadata" => %{
+                     "recent_commit_count" => 2,
+                     "total_commit_count" => 2
+                   },
+                   "type" => "contributor",
+                   "username" => "bar"
+                 }
+               ]
+             }
+    end
   end
 
   test "POST /webhooks without stacks", %{conn: conn} do
@@ -126,34 +135,39 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
       "pull_request" => %{"user" => %{"login" => "remiprev"}, "body" => "Foo"}
     }
 
-    Dispatch.Repositories.MockClient
-    |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
-    |> expect(:fetch_contributors, fn "mirego/foo" -> @contributors end)
-    |> expect(:request_reviewers, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :ok end)
-    |> expect(:create_request_comment, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :ok end)
+    with_mock Random,
+      uniform: fn
+        3 -> 1
+      end do
+      Dispatch.Repositories.MockClient
+      |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
+      |> expect(:fetch_contributors, fn "mirego/foo" -> @contributors end)
+      |> expect(:request_reviewers, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :ok end)
+      |> expect(:create_request_comment, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :ok end)
 
-    Dispatch.Settings.MockClient
-    |> expect(:refresh, fn -> true end)
-    |> expect(:blocklisted_users, fn -> [] end)
+      Dispatch.Settings.MockClient
+      |> expect(:refresh, fn -> true end)
+      |> expect(:blocklisted_users, fn -> [] end)
 
-    expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
+      expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
 
-    conn = post(conn, "/webhooks", params)
+      conn = post(conn, "/webhooks", params)
 
-    assert json_response(conn, 200) == %{
-             "success" => true,
-             "noop" => false,
-             "reviewers" => [
-               %{
-                 "metadata" => %{
-                   "recent_commit_count" => 1,
-                   "total_commit_count" => 1
-                 },
-                 "type" => "contributor",
-                 "username" => "bar"
-               }
-             ]
-           }
+      assert json_response(conn, 200) == %{
+               "success" => true,
+               "noop" => false,
+               "reviewers" => [
+                 %{
+                   "metadata" => %{
+                     "recent_commit_count" => 2,
+                     "total_commit_count" => 2
+                   },
+                   "type" => "contributor",
+                   "username" => "bar"
+                 }
+               ]
+             }
+    end
   end
 
   test "POST /webhooks with stacks", %{conn: conn} do
@@ -165,63 +179,68 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
       "pull_request" => %{"user" => %{"login" => "remiprev"}, "body" => "Foo"}
     }
 
-    Dispatch.Repositories.MockClient
-    |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
-    |> expect(:fetch_contributors, fn "mirego/foo" -> @contributors end)
-    |> expect(:request_reviewers, fn "mirego/foo",
-                                     1,
-                                     [
-                                       %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 1, total_commit_count: 1}},
-                                       %SelectedUser{username: "biz", type: "reviewer", metadata: %{stack: "graphql"}}
-                                     ] ->
-      :ok
-    end)
-    |> expect(:create_request_comment, fn "mirego/foo",
-                                          1,
-                                          [
-                                            %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 1, total_commit_count: 1}},
-                                            %SelectedUser{username: "biz", type: "reviewer", metadata: %{stack: "graphql"}},
-                                            %SelectedUser{username: "pif", type: "learner", metadata: %{stack: "elixir"}}
-                                          ] ->
-      :ok
-    end)
+    with_mock Random,
+      uniform: fn
+        3 -> 1
+      end do
+      Dispatch.Repositories.MockClient
+      |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
+      |> expect(:fetch_contributors, fn "mirego/foo" -> @contributors end)
+      |> expect(:request_reviewers, fn "mirego/foo",
+                                       1,
+                                       [
+                                         %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 2, total_commit_count: 2}},
+                                         %SelectedUser{username: "biz", type: "reviewer", metadata: %{stack: "graphql"}}
+                                       ] ->
+        :ok
+      end)
+      |> expect(:create_request_comment, fn "mirego/foo",
+                                            1,
+                                            [
+                                              %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 2, total_commit_count: 2}},
+                                              %SelectedUser{username: "biz", type: "reviewer", metadata: %{stack: "graphql"}},
+                                              %SelectedUser{username: "pif", type: "learner", metadata: %{stack: "elixir"}}
+                                            ] ->
+        :ok
+      end)
 
-    Dispatch.Settings.MockClient
-    |> expect(:refresh, fn -> true end)
-    |> expect(:blocklisted_users, fn -> [%BlocklistedUser{username: "foo"}] end)
-    |> expect(:reviewer_users, fn "elixir" -> [%Reviewer{username: "foo"}] end)
-    |> expect(:reviewer_users, fn "graphql" -> [%Reviewer{username: "biz"}, %Reviewer{username: "omg"}] end)
-    |> expect(:learner_users, fn "elixir" -> [%Learner{username: "paf", exposure: 0}, %Learner{username: "pif", exposure: 1}] end)
-    |> expect(:learner_users, fn "graphql" -> [] end)
+      Dispatch.Settings.MockClient
+      |> expect(:refresh, fn -> true end)
+      |> expect(:blocklisted_users, fn -> [%BlocklistedUser{username: "foo"}] end)
+      |> expect(:reviewer_users, fn "elixir" -> [%Reviewer{username: "foo"}] end)
+      |> expect(:reviewer_users, fn "graphql" -> [%Reviewer{username: "biz"}, %Reviewer{username: "omg"}] end)
+      |> expect(:learner_users, fn "elixir" -> [%Learner{username: "paf", exposure: 0}, %Learner{username: "pif", exposure: 1}] end)
+      |> expect(:learner_users, fn "graphql" -> [] end)
 
-    expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
+      expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
 
-    conn = post(conn, "/webhooks", params)
+      conn = post(conn, "/webhooks", params)
 
-    assert json_response(conn, 200) == %{
-             "success" => true,
-             "noop" => false,
-             "reviewers" => [
-               %{
-                 "metadata" => %{
-                   "recent_commit_count" => 1,
-                   "total_commit_count" => 1
+      assert json_response(conn, 200) == %{
+               "success" => true,
+               "noop" => false,
+               "reviewers" => [
+                 %{
+                   "metadata" => %{
+                     "recent_commit_count" => 2,
+                     "total_commit_count" => 2
+                   },
+                   "type" => "contributor",
+                   "username" => "bar"
                  },
-                 "type" => "contributor",
-                 "username" => "bar"
-               },
-               %{
-                 "metadata" => %{"stack" => "graphql"},
-                 "type" => "reviewer",
-                 "username" => "biz"
-               },
-               %{
-                 "metadata" => %{"stack" => "elixir", "exposure" => 1},
-                 "type" => "learner",
-                 "username" => "pif"
-               }
-             ]
-           }
+                 %{
+                   "metadata" => %{"stack" => "graphql"},
+                   "type" => "reviewer",
+                   "username" => "biz"
+                 },
+                 %{
+                   "metadata" => %{"stack" => "elixir", "exposure" => 1},
+                   "type" => "learner",
+                   "username" => "pif"
+                 }
+               ]
+             }
+    end
   end
 
   test "POST /webhooks with stacks but overriden in pull request body", %{conn: conn} do
@@ -233,58 +252,63 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
       "pull_request" => %{"user" => %{"login" => "remiprev"}, "body" => "Foo!\n\n#dispatch/ruby"}
     }
 
-    Dispatch.Repositories.MockClient
-    |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
-    |> expect(:fetch_contributors, fn "mirego/foo" -> @contributors end)
-    |> expect(:request_reviewers, fn "mirego/foo",
-                                     1,
-                                     [
-                                       %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 1, total_commit_count: 1}},
-                                       %SelectedUser{username: "ruby-master", type: "reviewer", metadata: %{stack: "ruby"}}
-                                     ] ->
-      :ok
-    end)
-    |> expect(:create_request_comment, fn "mirego/foo",
-                                          1,
-                                          [
-                                            %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 1, total_commit_count: 1}},
-                                            %SelectedUser{username: "ruby-master", type: "reviewer", metadata: %{stack: "ruby"}},
-                                            %SelectedUser{username: "ruby-learner", type: "learner", metadata: %{stack: "ruby"}}
-                                          ] ->
-      :ok
-    end)
+    with_mock Random,
+      uniform: fn
+        3 -> 1
+      end do
+      Dispatch.Repositories.MockClient
+      |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
+      |> expect(:fetch_contributors, fn "mirego/foo" -> @contributors end)
+      |> expect(:request_reviewers, fn "mirego/foo",
+                                       1,
+                                       [
+                                         %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 2, total_commit_count: 2}},
+                                         %SelectedUser{username: "ruby-master", type: "reviewer", metadata: %{stack: "ruby"}}
+                                       ] ->
+        :ok
+      end)
+      |> expect(:create_request_comment, fn "mirego/foo",
+                                            1,
+                                            [
+                                              %SelectedUser{username: "bar", type: "contributor", metadata: %{recent_commit_count: 2, total_commit_count: 2}},
+                                              %SelectedUser{username: "ruby-master", type: "reviewer", metadata: %{stack: "ruby"}},
+                                              %SelectedUser{username: "ruby-learner", type: "learner", metadata: %{stack: "ruby"}}
+                                            ] ->
+        :ok
+      end)
 
-    Dispatch.Settings.MockClient
-    |> expect(:refresh, fn -> true end)
-    |> expect(:blocklisted_users, fn -> [%BlocklistedUser{username: "foo"}] end)
-    |> expect(:reviewer_users, fn "ruby" -> [%Reviewer{username: "ruby-master"}] end)
-    |> expect(:learner_users, fn "ruby" -> [%Learner{username: "ruby-learner", exposure: 1}] end)
+      Dispatch.Settings.MockClient
+      |> expect(:refresh, fn -> true end)
+      |> expect(:blocklisted_users, fn -> [%BlocklistedUser{username: "foo"}] end)
+      |> expect(:reviewer_users, fn "ruby" -> [%Reviewer{username: "ruby-master"}] end)
+      |> expect(:learner_users, fn "ruby" -> [%Learner{username: "ruby-learner", exposure: 1}] end)
 
-    expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
+      expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
 
-    conn = post(conn, "/webhooks", params)
+      conn = post(conn, "/webhooks", params)
 
-    assert json_response(conn, 200) == %{
-             "success" => true,
-             "noop" => false,
-             "reviewers" => [
-               %{
-                 "metadata" => %{"recent_commit_count" => 1, "total_commit_count" => 1},
-                 "type" => "contributor",
-                 "username" => "bar"
-               },
-               %{
-                 "metadata" => %{"stack" => "ruby"},
-                 "type" => "reviewer",
-                 "username" => "ruby-master"
-               },
-               %{
-                 "metadata" => %{"stack" => "ruby", "exposure" => 1},
-                 "type" => "learner",
-                 "username" => "ruby-learner"
-               }
-             ]
-           }
+      assert json_response(conn, 200) == %{
+               "success" => true,
+               "noop" => false,
+               "reviewers" => [
+                 %{
+                   "metadata" => %{"recent_commit_count" => 2, "total_commit_count" => 2},
+                   "type" => "contributor",
+                   "username" => "bar"
+                 },
+                 %{
+                   "metadata" => %{"stack" => "ruby"},
+                   "type" => "reviewer",
+                   "username" => "ruby-master"
+                 },
+                 %{
+                   "metadata" => %{"stack" => "ruby", "exposure" => 1},
+                   "type" => "learner",
+                   "username" => "ruby-learner"
+                 }
+               ]
+             }
+    end
   end
 
   test "POST /webhooks with stacks but request return error", %{conn: conn} do
@@ -296,24 +320,29 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
       "pull_request" => %{"user" => %{"login" => "remiprev"}, "body" => "Foo"}
     }
 
-    Dispatch.Repositories.MockClient
-    |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
-    |> expect(:fetch_contributors, fn "mirego/foo" -> @contributors end)
-    |> expect(:request_reviewers, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :error end)
-    |> expect(:create_request_comment, 0, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :error end)
+    with_mock Random,
+      uniform: fn
+        3 -> 1
+      end do
+      Dispatch.Repositories.MockClient
+      |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
+      |> expect(:fetch_contributors, fn "mirego/foo" -> @contributors end)
+      |> expect(:request_reviewers, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :error end)
+      |> expect(:create_request_comment, 0, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :error end)
 
-    Dispatch.Settings.MockClient
-    |> expect(:refresh, fn -> true end)
-    |> expect(:blocklisted_users, fn -> [] end)
-    |> expect(:reviewer_users, fn "elixir" -> [] end)
-    |> expect(:reviewer_users, fn "graphql" -> [] end)
-    |> expect(:learner_users, fn "elixir" -> [] end)
-    |> expect(:learner_users, fn "graphql" -> [] end)
+      Dispatch.Settings.MockClient
+      |> expect(:refresh, fn -> true end)
+      |> expect(:blocklisted_users, fn -> [] end)
+      |> expect(:reviewer_users, fn "elixir" -> [] end)
+      |> expect(:reviewer_users, fn "graphql" -> [] end)
+      |> expect(:learner_users, fn "elixir" -> [] end)
+      |> expect(:learner_users, fn "graphql" -> [] end)
 
-    expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
+      expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
 
-    conn = post(conn, "/webhooks", params)
-    assert json_response(conn, 200) == %{"success" => false, "noop" => false}
+      conn = post(conn, "/webhooks", params)
+      assert json_response(conn, 200) == %{"success" => false, "noop" => false}
+    end
   end
 
   test "POST /webhooks from a non-organization pull request", %{conn: conn} do
@@ -366,33 +395,91 @@ defmodule DispatchWeb.Webhooks.ControllerTest do
       "pull_request" => %{"user" => %{"login" => "remiprev"}, "body" => "Foo"}
     }
 
-    Dispatch.Repositories.MockClient
-    |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
-    |> expect(:fetch_contributors, fn "mirego/foo" -> @contributors end)
-    |> expect(:request_reviewers, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :ok end)
-    |> expect(:create_request_comment, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :ok end)
+    with_mock Random,
+      uniform: fn
+        3 -> 1
+      end do
+      Dispatch.Repositories.MockClient
+      |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
+      |> expect(:fetch_contributors, fn "mirego/foo" -> @contributors end)
+      |> expect(:request_reviewers, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :ok end)
+      |> expect(:create_request_comment, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}] -> :ok end)
 
-    Dispatch.Settings.MockClient
-    |> expect(:refresh, fn -> true end)
-    |> expect(:blocklisted_users, fn -> [] end)
+      Dispatch.Settings.MockClient
+      |> expect(:refresh, fn -> true end)
+      |> expect(:blocklisted_users, fn -> [] end)
 
-    expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
+      expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
 
-    conn = post(conn, "/webhooks", params)
+      conn = post(conn, "/webhooks", params)
 
-    assert json_response(conn, 200) == %{
-             "success" => true,
-             "noop" => false,
-             "reviewers" => [
-               %{
-                 "metadata" => %{
-                   "recent_commit_count" => 1,
-                   "total_commit_count" => 1
+      assert json_response(conn, 200) == %{
+               "success" => true,
+               "noop" => false,
+               "reviewers" => [
+                 %{
+                   "metadata" => %{
+                     "recent_commit_count" => 2,
+                     "total_commit_count" => 2
+                   },
+                   "type" => "contributor",
+                   "username" => "bar"
+                 }
+               ]
+             }
+    end
+  end
+
+  test "POST /webhooks with minimum_contributor_count flag", %{conn: conn} do
+    params = %{
+      "minimum_contributor_count" => 2,
+      "action" => "opened",
+      "number" => 1,
+      "repository" => %{"full_name" => "mirego/foo", "owner" => %{"login" => "mirego"}},
+      "pull_request" => %{"user" => %{"login" => "remiprev"}, "body" => "Foo"}
+    }
+
+    with_mock Random,
+      uniform: fn
+        3 -> 1
+        1 -> 1
+      end do
+      Dispatch.Repositories.MockClient
+      |> expect(:fetch_requestable_users, fn "mirego/foo" -> @requestable_users end)
+      |> expect(:fetch_contributors, fn "mirego/foo" -> @contributors end)
+      |> expect(:request_reviewers, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}, %SelectedUser{username: "biz", type: "contributor"}] -> :ok end)
+      |> expect(:create_request_comment, fn "mirego/foo", 1, [%SelectedUser{username: "bar", type: "contributor"}, %SelectedUser{username: "biz", type: "contributor"}] -> :ok end)
+
+      Dispatch.Settings.MockClient
+      |> expect(:refresh, fn -> true end)
+      |> expect(:blocklisted_users, fn -> [] end)
+
+      expect(Dispatch.Absences.MockClient, :fetch_absents, fn -> [] end)
+
+      conn = post(conn, "/webhooks", params)
+
+      assert json_response(conn, 200) == %{
+               "success" => true,
+               "noop" => false,
+               "reviewers" => [
+                 %{
+                   "metadata" => %{
+                     "recent_commit_count" => 2,
+                     "total_commit_count" => 2
+                   },
+                   "type" => "contributor",
+                   "username" => "bar"
                  },
-                 "type" => "contributor",
-                 "username" => "bar"
-               }
-             ]
-           }
+                 %{
+                   "metadata" => %{
+                     "recent_commit_count" => 1,
+                     "total_commit_count" => 1
+                   },
+                   "type" => "contributor",
+                   "username" => "biz"
+                 }
+               ]
+             }
+    end
   end
 end


### PR DESCRIPTION
## 📖 Description

Small improvement to allow repositories to specify a `minimum_contributor_count` to select more than one contributor. We have a more complex project that need to be able to specify at least 2 contributors per Pull Request.

## 🦀 Dispatch

`#dispatch/elixir`